### PR TITLE
Use Python 3 Explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ install::
 		yarn install --offline --production && \
 		(yarn unlink > /dev/null 2>&1 || true) && \
 		yarn link
-	cd ${PACKDIR}/python/bin && $(PIP) install --user -e .
 
 test_all::
 	PATH=$(PULUMI_BIN):$(PATH) go test -v -count=1 -cover -timeout 1h -parallel ${TESTPARALLELISM} ./examples

--- a/build/common.mk
+++ b/build/common.mk
@@ -112,41 +112,8 @@ GO_TEST = go test -v -count=1 -cover -timeout 1h -parallel ${TESTPARALLELISM}
 # ensure that `default` is the target that is run when no arguments are passed to make
 default::
 
-# Ensure the requisite tools are on the PATH.
-#     - Prefer Python2 over Python.
-PYTHON := $(shell command -v python2 2>/dev/null)
-ifeq ($(PYTHON),)
-	PYTHON = $(shell command -v python 2>/dev/null)
-endif
-ifeq ($(PYTHON),)
-ensure::
-	$(error "missing python 2.7 (`python2` or `python`) from your $$PATH; \
-		please see https://github.com/pulumi/home/wiki/Package-Management-Prerequisites")
-else
-PYTHON_VERSION := $(shell command $(PYTHON) --version 2>&1)
-ifeq (,$(findstring 2.7,$(PYTHON_VERSION)))
-ensure::
-	$(error "$(PYTHON) did not report a 2.7 version number ($(PYTHON_VERSION)); \
-		please see https://github.com/pulumi/home/wiki/Package-Management-Prerequisites")
-endif
-endif
-#     - Prefer Pip2 over Pip.
-PIP := $(shell command -v pip2 2>/dev/null)
-ifeq ($(PIP),)
-	PIP = $(shell command -v pip 2>/dev/null)
-endif
-ifeq ($(PIP),)
-ensure::
-	$(error "missing pip 2.7 (`pip2` or `pip`) from your $$PATH; \
-		please see https://github.com/pulumi/home/wiki/Package-Management-Prerequisites")
-else
-PIP_VERSION := $(shell command $(PIP) --version 2>&1)
-ifeq (,$(findstring python 2.7,$(PIP_VERSION)))
-ensure::
-	$(error "$(PIP) did not report a 2.7 version number ($(PIP_VERSION)); \
-		please see https://github.com/pulumi/home/wiki/Package-Management-Prerequisites")
-endif
-endif
+PYTHON ?= python3
+PIP ?= pip3
 
 # If there are sub projects, our default, all, and ensure targets will
 # recurse into them.


### PR DESCRIPTION
- Remove check for Python 2.7 (we haven't used it in forever!)
- Invoke `pip3` and `python3` so we always get a Python 3 runtime
- Don't install the just built python package. We never use the version
  we install there and it's not great to just drop some random version
  of the package into the user's site-package (vs letting them install
  it into a virtualenv of their choice)