### PR TITLE
Fix name of python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ or `yarn`:
 
 To use from Python, install using `pip`:
 
-    $ pip install pulumi_azuread
+    $ pip install pulumi-azuread
 
 ### Go
 


### PR DESCRIPTION
Correct name is "pulumi-azuread" as seen on https://pypi.org/project/pulumi-azuread/