### PR TITLE
Enable and test OIDC support

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -7,6 +7,12 @@ env:
   ARM_SUBSCRIPTION_ID: "0282681f-7a9e-424b-80b2-96babd57a8a1"
   ARM_TENANT_ID: "706143bc-e1d4-4593-aee2-c9dc60ab9be7"
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+
+  # This GUID is AD app 'oidc-test'. Setting this variable will cause the OIDC test(s) to run against this app.
+  # We limit running the OIDC tests to PRs because the AD configuration requires an "Entity type" of Environment,
+  # Branch, Pull request, or Tag. See
+  # https://learn.microsoft.com/en-us/azure/active-directory/workload-identities/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-azp#github-actions
+  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
 makeTemplate: bridged
 team: ecosystem
 plugins:

--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -2,17 +2,17 @@ provider: azuread
 major-version: 5
 generate-nightly-test-workflow: true
 env:
-  ARM_CLIENT_ID: "30e520fa-12b4-4e21-b473-9426c5ac2e1e"
+  ARM_CLIENT_ID: "d3b6ec3a-36fe-46c9-b3d9-5856a2e0e73c" # test-app
   ARM_ENVIRONMENT: "public"
   ARM_SUBSCRIPTION_ID: "0282681f-7a9e-424b-80b2-96babd57a8a1"
-  ARM_TENANT_ID: "706143bc-e1d4-4593-aee2-c9dc60ab9be7"
-  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_TENANT_ID: "9605c22c-e585-4ea3-9b83-e90339719f8a" # pulumici.onmicrosoft.com
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET_CI }}
 
-  # This GUID is AD app 'oidc-test'. Setting this variable will cause the OIDC test(s) to run against this app.
+  # Setting this variable will cause the OIDC test(s) to run against this app.
   # We limit running the OIDC tests to PRs because the AD configuration requires an "Entity type" of Environment,
   # Branch, Pull request, or Tag. See
   # https://learn.microsoft.com/en-us/azure/active-directory/workload-identities/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-azp#github-actions
-  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
+  RUN_OIDC_TESTS: ${{ github.event_name == 'pull_request' && 'true' || '' }}
 makeTemplate: bridged
 team: ecosystem
 plugins:

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -2,11 +2,11 @@
 
 env:
   PROVIDER: azuread
-  ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
-  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_CLIENT_ID: d3b6ec3a-36fe-46c9-b3d9-5856a2e0e73c
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET_CI }}
   ARM_ENVIRONMENT: public
   ARM_SUBSCRIPTION_ID: 0282681f-7a9e-424b-80b2-96babd57a8a1
-  ARM_TENANT_ID: 706143bc-e1d4-4593-aee2-c9dc60ab9be7
+  ARM_TENANT_ID: 9605c22c-e585-4ea3-9b83-e90339719f8a
   DOTNETVERSION: |
       6.0.x
       3.1.301
@@ -18,7 +18,6 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
-  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
@@ -27,6 +26,7 @@ env:
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYTHONVERSION: "3.9"
+  RUN_OIDC_TESTS: ${{ github.event_name == 'pull_request' && 'true' || '' }}
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -18,6 +18,7 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -24,6 +24,7 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -8,11 +8,11 @@ on:
 
 
 env:
-  ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
-  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_CLIENT_ID: d3b6ec3a-36fe-46c9-b3d9-5856a2e0e73c
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET_CI }}
   ARM_ENVIRONMENT: public
   ARM_SUBSCRIPTION_ID: 0282681f-7a9e-424b-80b2-96babd57a8a1
-  ARM_TENANT_ID: 706143bc-e1d4-4593-aee2-c9dc60ab9be7
+  ARM_TENANT_ID: 9605c22c-e585-4ea3-9b83-e90339719f8a
   DOTNETVERSION: |
       6.0.x
       3.1.301
@@ -24,7 +24,6 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
-  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
@@ -33,6 +32,7 @@ env:
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYTHONVERSION: "3.9"
+  RUN_OIDC_TESTS: ${{ github.event_name == 'pull_request' && 'true' || '' }}
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,11 +7,11 @@ on:
     inputs: {}
 
 env:
-  ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
-  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_CLIENT_ID: d3b6ec3a-36fe-46c9-b3d9-5856a2e0e73c
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET_CI }}
   ARM_ENVIRONMENT: public
   ARM_SUBSCRIPTION_ID: 0282681f-7a9e-424b-80b2-96babd57a8a1
-  ARM_TENANT_ID: 706143bc-e1d4-4593-aee2-c9dc60ab9be7
+  ARM_TENANT_ID: 9605c22c-e585-4ea3-9b83-e90339719f8a
   DOTNETVERSION: |
       6.0.x
       3.1.301
@@ -23,7 +23,6 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
-  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
@@ -32,6 +31,7 @@ env:
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYTHONVERSION: "3.9"
+  RUN_OIDC_TESTS: ${{ github.event_name == 'pull_request' && 'true' || '' }}
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,11 +2,11 @@
 
 env:
   PROVIDER: azuread
-  ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
-  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_CLIENT_ID: d3b6ec3a-36fe-46c9-b3d9-5856a2e0e73c
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET_CI }}
   ARM_ENVIRONMENT: public
   ARM_SUBSCRIPTION_ID: 0282681f-7a9e-424b-80b2-96babd57a8a1
-  ARM_TENANT_ID: 706143bc-e1d4-4593-aee2-c9dc60ab9be7
+  ARM_TENANT_ID: 9605c22c-e585-4ea3-9b83-e90339719f8a
   DOTNETVERSION: |
       6.0.x
       3.1.301
@@ -18,7 +18,6 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
-  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
@@ -27,6 +26,7 @@ env:
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYTHONVERSION: "3.9"
+  RUN_OIDC_TESTS: ${{ github.event_name == 'pull_request' && 'true' || '' }}
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,6 +18,7 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -2,11 +2,11 @@
 
 env:
   PROVIDER: azuread
-  ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
-  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_CLIENT_ID: d3b6ec3a-36fe-46c9-b3d9-5856a2e0e73c
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET_CI }}
   ARM_ENVIRONMENT: public
   ARM_SUBSCRIPTION_ID: 0282681f-7a9e-424b-80b2-96babd57a8a1
-  ARM_TENANT_ID: 706143bc-e1d4-4593-aee2-c9dc60ab9be7
+  ARM_TENANT_ID: 9605c22c-e585-4ea3-9b83-e90339719f8a
   DOTNETVERSION: |
       6.0.x
       3.1.301
@@ -18,7 +18,6 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
-  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
@@ -27,6 +26,7 @@ env:
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYTHONVERSION: "3.9"
+  RUN_OIDC_TESTS: ${{ github.event_name == 'pull_request' && 'true' || '' }}
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -18,6 +18,7 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -19,6 +19,7 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,11 +3,11 @@
 env:
   PROVIDER: azuread
   IS_PRERELEASE: true
-  ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
-  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_CLIENT_ID: d3b6ec3a-36fe-46c9-b3d9-5856a2e0e73c
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET_CI }}
   ARM_ENVIRONMENT: public
   ARM_SUBSCRIPTION_ID: 0282681f-7a9e-424b-80b2-96babd57a8a1
-  ARM_TENANT_ID: 706143bc-e1d4-4593-aee2-c9dc60ab9be7
+  ARM_TENANT_ID: 9605c22c-e585-4ea3-9b83-e90339719f8a
   DOTNETVERSION: |
       6.0.x
       3.1.301
@@ -19,7 +19,6 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
-  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
@@ -28,6 +27,7 @@ env:
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYTHONVERSION: "3.9"
+  RUN_OIDC_TESTS: ${{ github.event_name == 'pull_request' && 'true' || '' }}
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,11 +2,11 @@
 
 env:
   PROVIDER: azuread
-  ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
-  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_CLIENT_ID: d3b6ec3a-36fe-46c9-b3d9-5856a2e0e73c
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET_CI }}
   ARM_ENVIRONMENT: public
   ARM_SUBSCRIPTION_ID: 0282681f-7a9e-424b-80b2-96babd57a8a1
-  ARM_TENANT_ID: 706143bc-e1d4-4593-aee2-c9dc60ab9be7
+  ARM_TENANT_ID: 9605c22c-e585-4ea3-9b83-e90339719f8a
   DOTNETVERSION: |
       6.0.x
       3.1.301
@@ -18,7 +18,6 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
-  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
@@ -27,6 +26,7 @@ env:
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYTHONVERSION: "3.9"
+  RUN_OIDC_TESTS: ${{ github.event_name == 'pull_request' && 'true' || '' }}
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,6 +18,7 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,11 @@
 
 env:
   PROVIDER: azuread
-  ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
-  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_CLIENT_ID: d3b6ec3a-36fe-46c9-b3d9-5856a2e0e73c
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET_CI }}
   ARM_ENVIRONMENT: public
   ARM_SUBSCRIPTION_ID: 0282681f-7a9e-424b-80b2-96babd57a8a1
-  ARM_TENANT_ID: 706143bc-e1d4-4593-aee2-c9dc60ab9be7
+  ARM_TENANT_ID: 9605c22c-e585-4ea3-9b83-e90339719f8a
   DOTNETVERSION: |
       6.0.x
       3.1.301
@@ -18,7 +18,6 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
-  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
@@ -27,6 +26,7 @@ env:
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYTHONVERSION: "3.9"
+  RUN_OIDC_TESTS: ${{ github.event_name == 'pull_request' && 'true' || '' }}
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/resync-build.yml
+++ b/.github/workflows/resync-build.yml
@@ -20,6 +20,7 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/resync-build.yml
+++ b/.github/workflows/resync-build.yml
@@ -4,11 +4,11 @@ env:
   PROVIDER: azuread
   PULUMI_EXTRA_MAPPING_ERROR: true
   PULUMI_MISSING_MAPPING_ERROR: true
-  ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
-  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_CLIENT_ID: d3b6ec3a-36fe-46c9-b3d9-5856a2e0e73c
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET_CI }}
   ARM_ENVIRONMENT: public
   ARM_SUBSCRIPTION_ID: 0282681f-7a9e-424b-80b2-96babd57a8a1
-  ARM_TENANT_ID: 706143bc-e1d4-4593-aee2-c9dc60ab9be7
+  ARM_TENANT_ID: 9605c22c-e585-4ea3-9b83-e90339719f8a
   DOTNETVERSION: |
       6.0.x
       3.1.301
@@ -20,7 +20,6 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
-  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
@@ -29,6 +28,7 @@ env:
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYTHONVERSION: "3.9"
+  RUN_OIDC_TESTS: ${{ github.event_name == 'pull_request' && 'true' || '' }}
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -3,11 +3,11 @@
 env:
   PROVIDER: azuread
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
-  ARM_CLIENT_ID: 30e520fa-12b4-4e21-b473-9426c5ac2e1e
-  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+  ARM_CLIENT_ID: d3b6ec3a-36fe-46c9-b3d9-5856a2e0e73c
+  ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET_CI }}
   ARM_ENVIRONMENT: public
   ARM_SUBSCRIPTION_ID: 0282681f-7a9e-424b-80b2-96babd57a8a1
-  ARM_TENANT_ID: 706143bc-e1d4-4593-aee2-c9dc60ab9be7
+  ARM_TENANT_ID: 9605c22c-e585-4ea3-9b83-e90339719f8a
   DOTNETVERSION: |
       6.0.x
       3.1.301
@@ -19,7 +19,6 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
-  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
@@ -28,6 +27,7 @@ env:
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYTHONVERSION: "3.9"
+  RUN_OIDC_TESTS: ${{ github.event_name == 'pull_request' && 'true' || '' }}
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
   SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -19,6 +19,7 @@ env:
   NODEVERSION: 20.x
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  OIDC_ARM_CLIENT_ID: ${{ github.event_name == 'pull_request' && '89380e12-5be6-486a-89ef-eea107af2f47' || '' }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -1,9 +1,11 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+//go:build nodejs || all
 // +build nodejs all
 
 package examples
 
 import (
+	"os"
 	"path"
 	"testing"
 
@@ -30,6 +32,31 @@ func TestSimple(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:           path.Join(getCwd(t), "simple"),
+			RunUpdateTest: true,
+			Secrets: map[string]string{
+				"password": "SecretP@sswd99!",
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
+// The same test than the above, but authenticating via OIDC.
+func TestSimple_OIDC(t *testing.T) {
+	oidcClientId := os.Getenv("OIDC_ARM_CLIENT_ID")
+	if oidcClientId == "" {
+		t.Skip("Skipping OIDC test without OIDC_ARM_CLIENT_ID")
+	}
+
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "simple"),
+			Env: []string{
+				"ARM_USE_OIDC=true",
+				"ARM_CLIENT_ID=" + oidcClientId,
+				// not strictly necessary but making sure we test the OIDC path
+				"ARM_CLIENT_SECRET=",
+			},
 			RunUpdateTest: true,
 			Secrets: map[string]string{
 				"password": "SecretP@sswd99!",

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -43,8 +43,7 @@ func TestSimple(t *testing.T) {
 
 // The same test than the above, but authenticating via OIDC.
 func TestSimple_OIDC(t *testing.T) {
-	oidcClientId := os.Getenv("OIDC_ARM_CLIENT_ID")
-	if oidcClientId == "" {
+	if os.Getenv("RUN_OIDC_TESTS") != "true" {
 		t.Skip("Skipping OIDC test without OIDC_ARM_CLIENT_ID")
 	}
 
@@ -53,7 +52,6 @@ func TestSimple_OIDC(t *testing.T) {
 			Dir: path.Join(getCwd(t), "simple"),
 			Env: []string{
 				"ARM_USE_OIDC=true",
-				"ARM_CLIENT_ID=" + oidcClientId,
 				// not strictly necessary but making sure we test the OIDC path
 				"ARM_CLIENT_SECRET=",
 			},

--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -18,7 +18,7 @@ const user = new azuread.User("me", {
     displayName: serverRandomPet.id,
     mailNickname: randomString.result,
     password: password,
-    userPrincipalName: pulumi.interpolate`${randomString.result}@pulumi.onmicrosoft.com`,
+    userPrincipalName: pulumi.interpolate`${randomString.result}@pulumici.onmicrosoft.com`,
 });
 
 export const userid: pulumi.Output<string> = user.id;

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -4,10 +4,10 @@
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/random": "^4.0.0",
-        "@pulumi/azuread": "^2.0.0"
+        "@pulumi/azuread": "^5.0.0"
     },
     "devDependencies": {
-        "@types/node": "^10.0.0"
+        "@types/node": "^18.0.0"
     },
     "license": "Apache 2.0"
 }

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -3,7 +3,7 @@ module github.com/pulumi/pulumi-azuread/provider/v5
 go 1.21.3
 
 require (
-	github.com/hashicorp/go-azure-sdk v0.20231018.1171511
+	github.com/hashicorp/go-azure-sdk v0.20231117.1130141
 	github.com/hashicorp/terraform-provider-azuread/shim v0.0.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.66.0
 	github.com/pulumi/pulumi/sdk/v3 v3.94.2
@@ -105,7 +105,7 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-azure-helpers v0.62.0 // indirect
+	github.com/hashicorp/go-azure-helpers v0.63.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1548,11 +1548,11 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.55.0/go.mod h1:RQugkG8wEcNIjYmcBLHpuEI/u2mTJwO4r37rR/OKRpo=
-github.com/hashicorp/go-azure-helpers v0.62.0 h1:3Ob1yFAO71Pbdnm14HUI4dGZUaO/Nqmncu5cKMGsDBg=
-github.com/hashicorp/go-azure-helpers v0.62.0/go.mod h1:ELmZ65vzHJNTk6ml4jsPD+xq2gZb7t78D35s+XN02Kk=
+github.com/hashicorp/go-azure-helpers v0.63.0 h1:7bYnYZsqzPjxVevi0z8Irwp5DwS8okLcaA183DQAcmY=
+github.com/hashicorp/go-azure-helpers v0.63.0/go.mod h1:ELmZ65vzHJNTk6ml4jsPD+xq2gZb7t78D35s+XN02Kk=
 github.com/hashicorp/go-azure-sdk v0.20230331.1143618/go.mod h1:L9JXVUcnL0GjMizCnngYUlMp1lLhDBNgSTvn6Of/5O4=
-github.com/hashicorp/go-azure-sdk v0.20231018.1171511 h1:n+i2b1vZ5FX/KiIvRgKtMbUAPB2aGxUrAsS0PilCcMo=
-github.com/hashicorp/go-azure-sdk v0.20231018.1171511/go.mod h1:3IQjdvuhEckMgdWpvQs4e4VdiiRLIm4z82kO814t/Lw=
+github.com/hashicorp/go-azure-sdk v0.20231117.1130141 h1:JhWOkTga5fKzhBz9XJGV5wDkgJsOyLE8wSx/TmjRUkQ=
+github.com/hashicorp/go-azure-sdk v0.20231117.1130141/go.mod h1:mdU6Hrw1jPiwBFmENOcjRlkMWi6yRI0Tt+p4vmPvc0g=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -133,7 +133,7 @@ func preConfigureCallback(vars resource.PropertyMap, c tfshim.ResourceConfig) er
 		ClientCertificatePassword: stringValue(vars, "clientCertificatePassword", []string{"ARM_CLIENT_CERTIFICATE_PASSWORD"}),
 		ClientCertificatePath:     stringValue(vars, "clientCertificatePath", []string{"ARM_CLIENT_CERTIFICATE_PATH"}),
 
-		EnableAuthenticatingUsingManagedIdentity: boolValue(vars, "msiEndpoint", []string{"ARM_USE_MSI"}),
+		EnableAuthenticatingUsingManagedIdentity: boolValue(vars, "useMsi", []string{"ARM_USE_MSI"}),
 		CustomManagedIdentityEndpoint:            stringValue(vars, "msiEndpoint", []string{"ARM_MSI_ENDPOINT"}),
 
 		// The configuration below would enable OIDC auth which we haven't tested and documented yet.


### PR DESCRIPTION
The dependencies this provider uses to authenticate to Azure already support OIDC. This PR enables the configuration, and adds an e2e test that authenticates to Azure via OIDC.

Also, it fixes an unrelated old bug I spotted where the wrong config key was used for MSI configuration.

The PR should be reasonably reviewable commit by commit.

- Upgrade auth dependencies
- Fix old bug: wrong config key for ARM_USE_MSI
- Enable OIDC auth in configuration
- Use tfbridge helpers to access configuration
- Update outdated dependencies of examples/simple
- Add an OIDC test
- Set the OIDC client id in PRs so the OIDC test runs
- `make ci-mgmt` to apply 4c75a05 "Set the OIDC client id in PRs so the OIDC test runs"
- Switch to the new Azure `pulumici` tenant and app - for details please see the internal document _Adding a dedicated tenant for Azure CI testing_
