### PR TITLE
metadata_host is marked as required upstream but actually isn't

### DIFF
--- a/provider/cmd/pulumi-resource-azuread/schema.json
+++ b/provider/cmd/pulumi-resource-azuread/schema.json
@@ -164,8 +164,7 @@
             }
         },
         "defaults": [
-            "environment",
-            "metadataHost"
+            "environment"
         ]
     },
     "types": {
@@ -3141,9 +3140,6 @@
                 "description": "Allow OpenID Connect to be used for authentication\n"
             }
         },
-        "required": [
-            "metadataHost"
-        ],
         "inputProperties": {
             "clientCertificate": {
                 "type": "string",
@@ -3248,10 +3244,7 @@
                 "type": "boolean",
                 "description": "Allow OpenID Connect to be used for authentication\n"
             }
-        },
-        "requiredInputs": [
-            "metadataHost"
-        ]
+        }
     },
     "resources": {
         "azuread:index/accessPackage:AccessPackage": {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -159,6 +159,9 @@ func Provider() tfbridge.ProviderInfo {
 					EnvVars: []string{"ARM_ENVIRONMENT"},
 				},
 			},
+			"metadata_host": {
+				MarkAsOptional: tfbridge.True(),
+			},
 			"msi_endpoint": {
 				Default: &tfbridge.DefaultInfo{
 					EnvVars: []string{"ARM_MSI_ENDPOINT"},

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -75,7 +75,7 @@ namespace Pulumi.AzureAD
         /// The Hostname which should be used for the Azure Metadata Service.
         /// </summary>
         [Output("metadataHost")]
-        public Output<string> MetadataHost { get; private set; } = null!;
+        public Output<string?> MetadataHost { get; private set; } = null!;
 
         /// <summary>
         /// The path to a custom endpoint for Managed Identity - in most circumstances this should be detected automatically
@@ -129,7 +129,7 @@ namespace Pulumi.AzureAD
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public Provider(string name, ProviderArgs args, CustomResourceOptions? options = null)
+        public Provider(string name, ProviderArgs? args = null, CustomResourceOptions? options = null)
             : base("azuread", name, args ?? new ProviderArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -244,8 +244,8 @@ namespace Pulumi.AzureAD
         /// <summary>
         /// The Hostname which should be used for the Azure Metadata Service.
         /// </summary>
-        [Input("metadataHost", required: true)]
-        public Input<string> MetadataHost { get; set; } = null!;
+        [Input("metadataHost")]
+        public Input<string>? MetadataHost { get; set; }
 
         /// <summary>
         /// The path to a custom endpoint for Managed Identity - in most circumstances this should be detected automatically

--- a/sdk/go/azuread/provider.go
+++ b/sdk/go/azuread/provider.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"errors"
 	"github.com/pulumi/pulumi-azuread/sdk/v5/go/azuread/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -41,7 +40,7 @@ type Provider struct {
 	// when `metadataHost` is specified.
 	Environment pulumi.StringPtrOutput `pulumi:"environment"`
 	// The Hostname which should be used for the Azure Metadata Service.
-	MetadataHost pulumi.StringOutput `pulumi:"metadataHost"`
+	MetadataHost pulumi.StringPtrOutput `pulumi:"metadataHost"`
 	// The path to a custom endpoint for Managed Identity - in most circumstances this should be detected automatically
 	MsiEndpoint pulumi.StringPtrOutput `pulumi:"msiEndpoint"`
 	// The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID
@@ -64,12 +63,9 @@ type Provider struct {
 func NewProvider(ctx *pulumi.Context,
 	name string, args *ProviderArgs, opts ...pulumi.ResourceOption) (*Provider, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &ProviderArgs{}
 	}
 
-	if args.MetadataHost == nil {
-		return nil, errors.New("invalid value for required argument 'MetadataHost'")
-	}
 	if args.Environment == nil {
 		if d := internal.GetEnvOrDefault("public", nil, "ARM_ENVIRONMENT"); d != nil {
 			args.Environment = pulumi.StringPtr(d.(string))
@@ -133,7 +129,7 @@ type providerArgs struct {
 	// when `metadataHost` is specified.
 	Environment *string `pulumi:"environment"`
 	// The Hostname which should be used for the Azure Metadata Service.
-	MetadataHost string `pulumi:"metadataHost"`
+	MetadataHost *string `pulumi:"metadataHost"`
 	// The path to a custom endpoint for Managed Identity - in most circumstances this should be detected automatically
 	MsiEndpoint *string `pulumi:"msiEndpoint"`
 	// The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID
@@ -185,7 +181,7 @@ type ProviderArgs struct {
 	// when `metadataHost` is specified.
 	Environment pulumi.StringPtrInput
 	// The Hostname which should be used for the Azure Metadata Service.
-	MetadataHost pulumi.StringInput
+	MetadataHost pulumi.StringPtrInput
 	// The path to a custom endpoint for Managed Identity - in most circumstances this should be detected automatically
 	MsiEndpoint pulumi.StringPtrInput
 	// The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID
@@ -295,8 +291,8 @@ func (o ProviderOutput) Environment() pulumi.StringPtrOutput {
 }
 
 // The Hostname which should be used for the Azure Metadata Service.
-func (o ProviderOutput) MetadataHost() pulumi.StringOutput {
-	return o.ApplyT(func(v *Provider) pulumi.StringOutput { return v.MetadataHost }).(pulumi.StringOutput)
+func (o ProviderOutput) MetadataHost() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Provider) pulumi.StringPtrOutput { return v.MetadataHost }).(pulumi.StringPtrOutput)
 }
 
 // The path to a custom endpoint for Managed Identity - in most circumstances this should be detected automatically

--- a/sdk/java/src/main/java/com/pulumi/azuread/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/azuread/Config.java
@@ -79,8 +79,8 @@ public final class Config {
  * The Hostname which should be used for the Azure Metadata Service.
  * 
  */
-    public String metadataHost() {
-        return Codegen.stringProp("metadataHost").config(config).require();
+    public Optional<String> metadataHost() {
+        return Codegen.stringProp("metadataHost").config(config).get();
     }
 /**
  * The path to a custom endpoint for Managed Identity - in most circumstances this should be detected automatically

--- a/sdk/java/src/main/java/com/pulumi/azuread/Provider.java
+++ b/sdk/java/src/main/java/com/pulumi/azuread/Provider.java
@@ -150,14 +150,14 @@ public class Provider extends com.pulumi.resources.ProviderResource {
      * 
      */
     @Export(name="metadataHost", refs={String.class}, tree="[0]")
-    private Output<String> metadataHost;
+    private Output</* @Nullable */ String> metadataHost;
 
     /**
      * @return The Hostname which should be used for the Azure Metadata Service.
      * 
      */
-    public Output<String> metadataHost() {
-        return this.metadataHost;
+    public Output<Optional<String>> metadataHost() {
+        return Codegen.optional(this.metadataHost);
     }
     /**
      * The path to a custom endpoint for Managed Identity - in most circumstances this should be detected automatically
@@ -274,7 +274,7 @@ public class Provider extends com.pulumi.resources.ProviderResource {
      * @param name The _unique_ name of the resulting resource.
      * @param args The arguments to use to populate this resource's properties.
      */
-    public Provider(String name, ProviderArgs args) {
+    public Provider(String name, @Nullable ProviderArgs args) {
         this(name, args, null);
     }
     /**
@@ -283,7 +283,7 @@ public class Provider extends com.pulumi.resources.ProviderResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param options A bag of options that control this resource's behavior.
      */
-    public Provider(String name, ProviderArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    public Provider(String name, @Nullable ProviderArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         super("azuread", name, args == null ? ProviderArgs.Empty : args, makeResourceOptions(options, Codegen.empty()));
     }
 

--- a/sdk/java/src/main/java/com/pulumi/azuread/ProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/azuread/ProviderArgs.java
@@ -6,7 +6,6 @@ package com.pulumi.azuread;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import com.pulumi.core.internal.Codegen;
-import com.pulumi.exceptions.MissingRequiredPropertyException;
 import java.lang.Boolean;
 import java.lang.String;
 import java.util.Objects;
@@ -159,15 +158,15 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
      * The Hostname which should be used for the Azure Metadata Service.
      * 
      */
-    @Import(name="metadataHost", required=true)
-    private Output<String> metadataHost;
+    @Import(name="metadataHost")
+    private @Nullable Output<String> metadataHost;
 
     /**
      * @return The Hostname which should be used for the Azure Metadata Service.
      * 
      */
-    public Output<String> metadataHost() {
-        return this.metadataHost;
+    public Optional<Output<String>> metadataHost() {
+        return Optional.ofNullable(this.metadataHost);
     }
 
     /**
@@ -576,7 +575,7 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder metadataHost(Output<String> metadataHost) {
+        public Builder metadataHost(@Nullable Output<String> metadataHost) {
             $.metadataHost = metadataHost;
             return this;
         }
@@ -828,9 +827,6 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
 
         public ProviderArgs build() {
             $.environment = Codegen.stringProp("environment").output().arg($.environment).env("ARM_ENVIRONMENT").def("public").getNullable();
-            if ($.metadataHost == null) {
-                throw new MissingRequiredPropertyException("ProviderArgs", "metadataHost");
-            }
             $.msiEndpoint = Codegen.stringProp("msiEndpoint").output().arg($.msiEndpoint).env("ARM_MSI_ENDPOINT").getNullable();
             $.useMsi = Codegen.booleanProp("useMsi").output().arg($.useMsi).env("ARM_USE_MSI").def(false).getNullable();
             return $;

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -65,7 +65,7 @@ export class Provider extends pulumi.ProviderResource {
     /**
      * The Hostname which should be used for the Azure Metadata Service.
      */
-    public readonly metadataHost!: pulumi.Output<string>;
+    public readonly metadataHost!: pulumi.Output<string | undefined>;
     /**
      * The path to a custom endpoint for Managed Identity - in most circumstances this should be detected automatically
      */
@@ -104,13 +104,10 @@ export class Provider extends pulumi.ProviderResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: ProviderArgs, opts?: pulumi.ResourceOptions) {
+    constructor(name: string, args?: ProviderArgs, opts?: pulumi.ResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         {
-            if ((!args || args.metadataHost === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'metadataHost'");
-            }
             resourceInputs["clientCertificate"] = args ? args.clientCertificate : undefined;
             resourceInputs["clientCertificatePassword"] = args?.clientCertificatePassword ? pulumi.secret(args.clientCertificatePassword) : undefined;
             resourceInputs["clientCertificatePath"] = args ? args.clientCertificatePath : undefined;
@@ -185,7 +182,7 @@ export interface ProviderArgs {
     /**
      * The Hostname which should be used for the Azure Metadata Service.
      */
-    metadataHost: pulumi.Input<string>;
+    metadataHost?: pulumi.Input<string>;
     /**
      * The path to a custom endpoint for Managed Identity - in most circumstances this should be detected automatically
      */

--- a/sdk/python/pulumi_azuread/provider.py
+++ b/sdk/python/pulumi_azuread/provider.py
@@ -19,7 +19,6 @@ __all__ = ['ProviderArgs', 'Provider']
 @pulumi.input_type
 class ProviderArgs:
     def __init__(__self__, *,
-                 metadata_host: pulumi.Input[str],
                  client_certificate: Optional[pulumi.Input[str]] = None,
                  client_certificate_password: Optional[pulumi.Input[str]] = None,
                  client_certificate_path: Optional[pulumi.Input[str]] = None,
@@ -29,6 +28,7 @@ class ProviderArgs:
                  client_secret_file_path: Optional[pulumi.Input[str]] = None,
                  disable_terraform_partner_id: Optional[pulumi.Input[bool]] = None,
                  environment: Optional[pulumi.Input[str]] = None,
+                 metadata_host: Optional[pulumi.Input[str]] = None,
                  msi_endpoint: Optional[pulumi.Input[str]] = None,
                  oidc_request_token: Optional[pulumi.Input[str]] = None,
                  oidc_request_url: Optional[pulumi.Input[str]] = None,
@@ -42,7 +42,6 @@ class ProviderArgs:
                  use_oidc: Optional[pulumi.Input[bool]] = None):
         """
         The set of arguments for constructing a Provider resource.
-        :param pulumi.Input[str] metadata_host: The Hostname which should be used for the Azure Metadata Service.
         :param pulumi.Input[str] client_certificate: Base64 encoded PKCS#12 certificate bundle to use when authenticating as a Service Principal using a Client Certificate
         :param pulumi.Input[str] client_certificate_password: The password to decrypt the Client Certificate. For use when authenticating as a Service Principal using a Client
                Certificate
@@ -56,6 +55,7 @@ class ProviderArgs:
         :param pulumi.Input[str] environment: The cloud environment which should be used. Possible values are: `global` (also `public`), `usgovernmentl4` (also
                `usgovernment`), `usgovernmentl5` (also `dod`), and `china`. Defaults to `global`. Not used and should not be specified
                when `metadata_host` is specified.
+        :param pulumi.Input[str] metadata_host: The Hostname which should be used for the Azure Metadata Service.
         :param pulumi.Input[str] msi_endpoint: The path to a custom endpoint for Managed Identity - in most circumstances this should be detected automatically
         :param pulumi.Input[str] oidc_request_token: The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID
                Connect.
@@ -70,7 +70,6 @@ class ProviderArgs:
         :param pulumi.Input[bool] use_msi: Allow Managed Identity to be used for Authentication
         :param pulumi.Input[bool] use_oidc: Allow OpenID Connect to be used for authentication
         """
-        pulumi.set(__self__, "metadata_host", metadata_host)
         if client_certificate is not None:
             pulumi.set(__self__, "client_certificate", client_certificate)
         if client_certificate_password is not None:
@@ -91,6 +90,8 @@ class ProviderArgs:
             environment = (_utilities.get_env('ARM_ENVIRONMENT') or 'public')
         if environment is not None:
             pulumi.set(__self__, "environment", environment)
+        if metadata_host is not None:
+            pulumi.set(__self__, "metadata_host", metadata_host)
         if msi_endpoint is None:
             msi_endpoint = _utilities.get_env('ARM_MSI_ENDPOINT')
         if msi_endpoint is not None:
@@ -117,18 +118,6 @@ class ProviderArgs:
             pulumi.set(__self__, "use_msi", use_msi)
         if use_oidc is not None:
             pulumi.set(__self__, "use_oidc", use_oidc)
-
-    @property
-    @pulumi.getter(name="metadataHost")
-    def metadata_host(self) -> pulumi.Input[str]:
-        """
-        The Hostname which should be used for the Azure Metadata Service.
-        """
-        return pulumi.get(self, "metadata_host")
-
-    @metadata_host.setter
-    def metadata_host(self, value: pulumi.Input[str]):
-        pulumi.set(self, "metadata_host", value)
 
     @property
     @pulumi.getter(name="clientCertificate")
@@ -239,6 +228,18 @@ class ProviderArgs:
     @environment.setter
     def environment(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "environment", value)
+
+    @property
+    @pulumi.getter(name="metadataHost")
+    def metadata_host(self) -> Optional[pulumi.Input[str]]:
+        """
+        The Hostname which should be used for the Azure Metadata Service.
+        """
+        return pulumi.get(self, "metadata_host")
+
+    @metadata_host.setter
+    def metadata_host(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "metadata_host", value)
 
     @property
     @pulumi.getter(name="msiEndpoint")
@@ -442,7 +443,7 @@ class Provider(pulumi.ProviderResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: ProviderArgs,
+                 args: Optional[ProviderArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The provider type for the azuread package. By default, resources use package-wide configuration
@@ -506,8 +507,6 @@ class Provider(pulumi.ProviderResource):
             if environment is None:
                 environment = (_utilities.get_env('ARM_ENVIRONMENT') or 'public')
             __props__.__dict__["environment"] = environment
-            if metadata_host is None and not opts.urn:
-                raise TypeError("Missing required property 'metadata_host'")
             __props__.__dict__["metadata_host"] = metadata_host
             if msi_endpoint is None:
                 msi_endpoint = _utilities.get_env('ARM_MSI_ENDPOINT')
@@ -603,7 +602,7 @@ class Provider(pulumi.ProviderResource):
 
     @property
     @pulumi.getter(name="metadataHost")
-    def metadata_host(self) -> pulumi.Output[str]:
+    def metadata_host(self) -> pulumi.Output[Optional[str]]:
         """
         The Hostname which should be used for the Azure Metadata Service.
         """


### PR DESCRIPTION
Resolves #362 - users of this provider need to specify this config even if the default is fine.

The upstream provider [has this property marked as required](https://github.com/hashicorp/terraform-provider-azuread/blob/6594e1c6cd59ffc7f5e9a881412609d9cde816e7/internal/provider/provider.go#L126), but that works differently in Terraform: since there's also a `DefaultFunc` configured, the function's return value will be used if the user doesn't specify a value, and the function itself returns a default of `""`.  So a value is guaranteed, even if it's the empty string.

In Pulumi, "required" means needs to be configured by the user. Therefore, we mark this property as optional to get the same behavior as upstream.

