### PR TITLE
Don't auto-merge upstream upgrades

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -38,3 +38,4 @@ releaseVerification:
   python: examples/release-verification/py/user
   dotnet: examples/release-verification/cs/user
   go: examples/release-verification/go/user
+autoMergeProviderUpgrades: false


### PR DESCRIPTION
Sets the `AutoMergeProviderUpgrades` ci-mgmt config to false to avoid auto-merging upstream upgrades. This maintains the current behaviour.

Part of https://github.com/pulumi/ci-mgmt/issues/1344