### PR TITLE
Disallow missing resource docs on upgrades

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -31,6 +31,8 @@ license:
   ignore:
     - github.com/hashicorp/terraform-provider-azuread/shim
 
+allowMissingDocs: false
+
 # Use `pulumi convert` for translating examples from TF to Pulumi.
 pulumiConvert: 1
 releaseVerification:


### PR DESCRIPTION
Sets the `allowMissingDocs` ci-mgmt config to false to error on missing resource docs. This maintains the current behaviour.

Part of https://github.com/pulumi/upgrade-provider/issues/303