### PR TITLE
Use direct npm publish with backport tag for v5 branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -167,11 +167,27 @@ jobs:
         # we don't set node-version because we install with mise.
         # this step is needed to setup npm auth
         registry-url: https://registry.npmjs.org
-    - name: Publish SDKs
+    # ===== NodeJS SDK (direct npm with backport tag) =====
+    # Use direct npm publish with explicit tag to avoid tagging as 'latest'
+    # which would incorrectly mark this backport as the default version.
+    - name: Download nodejs SDK
+      uses: actions/download-artifact@v4
+      with:
+        name: nodejs-sdk.tar.gz
+        path: ${{ github.workspace }}/sdk/
+    - name: Uncompress nodejs SDK
+      run: mkdir -p ${{ github.workspace }}/sdk/nodejs && tar -zxf ${{ github.workspace }}/sdk/nodejs.tar.gz -C ${{ github.workspace }}/sdk/nodejs
+    - name: Publish Node SDK
+      working-directory: ${{ github.workspace }}/sdk/nodejs/bin
+      run: npm publish --tag latest-v5
+      env:
+        NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
+    # ===== Other SDKs via pulumi-package-publisher (excluding nodejs) =====
+    - name: Publish SDKs (Python, .NET, Java)
       if: inputs.skipJavaSdk == false
       uses: pulumi/pulumi-package-publisher@c1672c7928591d563dccb12729e05e315c21f8c2 # v0.0.22
       with:
-        sdk: all
+        sdk: all,!nodejs
         version: ${{ inputs.version }}
       env:
         PYPI_USERNAME: __token__
@@ -183,19 +199,16 @@ jobs:
         PUBLISH_REPO_PASSWORD: ${{ steps.esc-secrets.outputs.OSSRH_PASSWORD }}
         PUBLISH_REPO_USERNAME: ${{ steps.esc-secrets.outputs.OSSRH_USERNAME }}
         NUGET_PUBLISH_KEY: ${{ steps.esc-secrets.outputs.NUGET_PUBLISH_KEY }}
-    - name: Publish SDKs (except Java)
+    - name: Publish SDKs (Python, .NET - no Java)
       if: inputs.skipJavaSdk == true
       uses: pulumi/pulumi-package-publisher@c1672c7928591d563dccb12729e05e315c21f8c2 # v0.0.22
       with:
-        sdk: all,!java
+        sdk: all,!nodejs,!java
         version: ${{ inputs.version }}
       env:
         PYPI_USERNAME: __token__
         PYPI_PASSWORD: ${{ steps.esc-secrets.outputs.PYPI_API_TOKEN }}
         NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
-        SIGNING_KEY: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY }}
-        SIGNING_KEY_ID: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_KEY_ID }}
-        SIGNING_PASSWORD: ${{ steps.esc-secrets.outputs.JAVA_SIGNING_PASSWORD }}
         NUGET_PUBLISH_KEY: ${{ steps.esc-secrets.outputs.NUGET_PUBLISH_KEY }}
     - name: Download Go SDK
       uses: ./.github/actions/download-sdk


### PR DESCRIPTION
## Summary

The modernized ci-mgmt workflows use `pulumi package publish-sdk` which relies on the Pulumi CLI version pinned in go.mod (v3.133.0). This version doesn't support proper NPM tagging for backport releases - it would incorrectly tag the package as `latest` instead of leaving that tag on v6.x.

This change:
- Replaces the nodejs portion of `pulumi-package-publisher` with direct `npm publish --tag latest-v5`
- Keeps using `pulumi-package-publisher` for Python, .NET, and Java SDKs (they use native tooling internally)

## Consumer Impact

Consumers can install v5 releases via:
```bash
npm install @pulumi/azuread@latest-v5
```

## Context

Part of https://github.com/pulumi/home/issues/4396

Addresses the concern raised in PR #2168:
> Unfortunately, for publish to run correctly on NPM (and not tag a default `latest`), the pu/pu fix I pushed will not suffice, because we're not using that version of Pulumi to publish.
> We need to change the npm publish workflow to use the NPM cli directly.

## Test plan

- [ ] Manually trigger release workflow with a test prerelease version
- [ ] Verify NPM package appears with `latest-v5` tag (not `latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)