### PR TITLE
Add state transformers on Application and Service Principal

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"unicode"
 
 	// embed is used to store bridge-metadata.json in the compiled binary
@@ -129,21 +130,47 @@ func preConfigureCallback(vars resource.PropertyMap, _ tfshim.ResourceConfig) er
 	return nil
 }
 
-// migrateApplicationIdToClientId backfills clientId from applicationId in state from
-// before the upstream v2→v3 rename.
-func migrateApplicationIdToClientId(_ context.Context, state resource.PropertyMap) (resource.PropertyMap, error) {
+// migrateApplicationState carries v5 state through the v2→v3 rename of applicationId to
+// clientId and the bare-UUID to /applications/{id} format change.
+func migrateApplicationState(_ context.Context, state resource.PropertyMap) (resource.PropertyMap, error) {
+	backfillClientIDFromApplicationID(state)
+	prefixID(state, "/applications/")
+	return state, nil
+}
+
+// migrateServicePrincipalState carries v5 state through the same rename and the bare-UUID to
+// /servicePrincipals/{id} format change.
+func migrateServicePrincipalState(_ context.Context, state resource.PropertyMap) (resource.PropertyMap, error) {
+	backfillClientIDFromApplicationID(state)
+	prefixID(state, "/servicePrincipals/")
+	return state, nil
+}
+
+func backfillClientIDFromApplicationID(state resource.PropertyMap) {
 	const appIDKey = resource.PropertyKey("applicationId")
 	const clientIDKey = resource.PropertyKey("clientId")
 
 	appID, hasAppID := state[appIDKey]
 	if !hasAppID || !appID.IsString() || appID.StringValue() == "" {
-		return state, nil
+		return
 	}
 	if existing, hasClientID := state[clientIDKey]; hasClientID && existing.IsString() && existing.StringValue() != "" {
-		return state, nil
+		return
 	}
 	state[clientIDKey] = appID
-	return state, nil
+}
+
+func prefixID(state resource.PropertyMap, prefix string) {
+	const idKey = resource.PropertyKey("id")
+	id, hasID := state[idKey]
+	if !hasID || !id.IsString() {
+		return
+	}
+	s := id.StringValue()
+	if s == "" || strings.HasPrefix(s, prefix) {
+		return
+	}
+	state[idKey] = resource.NewStringProperty(prefix + s)
 }
 
 // Provider returns additional overlaid schema and metadata associated with the provider..
@@ -198,13 +225,13 @@ func Provider() tfbridge.ProviderInfo {
 		Resources: map[string]*tfbridge.ResourceInfo{
 			"azuread_application": {
 				Tok:                makeResource(mainMod, "Application"),
-				TransformFromState: migrateApplicationIdToClientId,
+				TransformFromState: migrateApplicationState,
 			},
 			"azuread_application_password": {Tok: makeResource(mainMod, "ApplicationPassword")},
 			"azuread_group":                {Tok: makeResource(mainMod, "Group")},
 			"azuread_service_principal": {
 				Tok:                makeResource(mainMod, "ServicePrincipal"),
-				TransformFromState: migrateApplicationIdToClientId,
+				TransformFromState: migrateServicePrincipalState,
 			},
 			"azuread_service_principal_password": {Tok: makeResource(mainMod, "ServicePrincipalPassword")},
 			"azuread_service_principal_delegated_permission_grant": {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -129,6 +129,23 @@ func preConfigureCallback(vars resource.PropertyMap, _ tfshim.ResourceConfig) er
 	return nil
 }
 
+// migrateApplicationIdToClientId backfills clientId from applicationId in state from
+// before the upstream v2→v3 rename.
+func migrateApplicationIdToClientId(_ context.Context, state resource.PropertyMap) (resource.PropertyMap, error) {
+	const appIDKey = resource.PropertyKey("applicationId")
+	const clientIDKey = resource.PropertyKey("clientId")
+
+	appID, hasAppID := state[appIDKey]
+	if !hasAppID || !appID.IsString() || appID.StringValue() == "" {
+		return state, nil
+	}
+	if existing, hasClientID := state[clientIDKey]; hasClientID && existing.IsString() && existing.StringValue() != "" {
+		return state, nil
+	}
+	state[clientIDKey] = appID
+	return state, nil
+}
+
 // Provider returns additional overlaid schema and metadata associated with the provider..
 func Provider() tfbridge.ProviderInfo {
 	// Instantiate the Terraform provider
@@ -179,10 +196,16 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		PreConfigureCallback: preConfigureCallback,
 		Resources: map[string]*tfbridge.ResourceInfo{
-			"azuread_application":                {Tok: makeResource(mainMod, "Application")},
-			"azuread_application_password":       {Tok: makeResource(mainMod, "ApplicationPassword")},
-			"azuread_group":                      {Tok: makeResource(mainMod, "Group")},
-			"azuread_service_principal":          {Tok: makeResource(mainMod, "ServicePrincipal")},
+			"azuread_application": {
+				Tok:                makeResource(mainMod, "Application"),
+				TransformFromState: migrateApplicationIdToClientId,
+			},
+			"azuread_application_password": {Tok: makeResource(mainMod, "ApplicationPassword")},
+			"azuread_group":                {Tok: makeResource(mainMod, "Group")},
+			"azuread_service_principal": {
+				Tok:                makeResource(mainMod, "ServicePrincipal"),
+				TransformFromState: migrateApplicationIdToClientId,
+			},
 			"azuread_service_principal_password": {Tok: makeResource(mainMod, "ServicePrincipalPassword")},
 			"azuread_service_principal_delegated_permission_grant": {
 				Tok: makeResource(mainMod, "ServicePrincipalDelegatedPermissionGrant"),

--- a/provider/state_migration_test.go
+++ b/provider/state_migration_test.go
@@ -6,8 +6,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func TestMigrateApplicationState(t *testing.T) {

--- a/provider/state_migration_test.go
+++ b/provider/state_migration_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026, Pulumi Corporation.
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateApplicationState(t *testing.T) {
+	t.Parallel()
+
+	const guid = "9456d3da-3f88-4c7b-90ed-181ab1ae0473"
+
+	cases := []struct {
+		name string
+		in   resource.PropertyMap
+		want resource.PropertyMap
+	}{
+		{
+			name: "v5 state is fully migrated",
+			in: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(guid),
+				"id":            resource.NewStringProperty(guid),
+			},
+			want: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(guid),
+				"clientId":      resource.NewStringProperty(guid),
+				"id":            resource.NewStringProperty("/applications/" + guid),
+			},
+		},
+		{
+			name: "already-migrated state is unchanged",
+			in: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(guid),
+				"clientId":      resource.NewStringProperty(guid),
+				"id":            resource.NewStringProperty("/applications/" + guid),
+			},
+			want: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(guid),
+				"clientId":      resource.NewStringProperty(guid),
+				"id":            resource.NewStringProperty("/applications/" + guid),
+			},
+		},
+		{
+			name: "existing clientId is preserved",
+			in: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(guid),
+				"clientId":      resource.NewStringProperty("custom"),
+				"id":            resource.NewStringProperty(guid),
+			},
+			want: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(guid),
+				"clientId":      resource.NewStringProperty("custom"),
+				"id":            resource.NewStringProperty("/applications/" + guid),
+			},
+		},
+		{
+			name: "missing applicationId leaves clientId alone",
+			in: resource.PropertyMap{
+				"id": resource.NewStringProperty(guid),
+			},
+			want: resource.PropertyMap{
+				"id": resource.NewStringProperty("/applications/" + guid),
+			},
+		},
+		{
+			name: "empty applicationId is not backfilled",
+			in: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(""),
+				"id":            resource.NewStringProperty(guid),
+			},
+			want: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(""),
+				"id":            resource.NewStringProperty("/applications/" + guid),
+			},
+		},
+		{
+			name: "empty clientId is treated as missing and backfilled",
+			in: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(guid),
+				"clientId":      resource.NewStringProperty(""),
+				"id":            resource.NewStringProperty(guid),
+			},
+			want: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(guid),
+				"clientId":      resource.NewStringProperty(guid),
+				"id":            resource.NewStringProperty("/applications/" + guid),
+			},
+		},
+		{
+			name: "missing id field is a no-op for id rewrite",
+			in: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(guid),
+			},
+			want: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(guid),
+				"clientId":      resource.NewStringProperty(guid),
+			},
+		},
+		{
+			name: "non-string id is left untouched",
+			in: resource.PropertyMap{
+				"id": resource.NewNumberProperty(42),
+			},
+			want: resource.PropertyMap{
+				"id": resource.NewNumberProperty(42),
+			},
+		},
+		{
+			name: "empty map is unchanged",
+			in:   resource.PropertyMap{},
+			want: resource.PropertyMap{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := migrateApplicationState(context.Background(), tc.in)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMigrateServicePrincipalState(t *testing.T) {
+	t.Parallel()
+
+	const guid = "fae162c3-ade4-49b5-84ba-a7254efa23be"
+
+	cases := []struct {
+		name string
+		in   resource.PropertyMap
+		want resource.PropertyMap
+	}{
+		{
+			name: "v5 state is fully migrated",
+			in: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(guid),
+				"id":            resource.NewStringProperty(guid),
+			},
+			want: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(guid),
+				"clientId":      resource.NewStringProperty(guid),
+				"id":            resource.NewStringProperty("/servicePrincipals/" + guid),
+			},
+		},
+		{
+			name: "already-migrated state is unchanged",
+			in: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(guid),
+				"clientId":      resource.NewStringProperty(guid),
+				"id":            resource.NewStringProperty("/servicePrincipals/" + guid),
+			},
+			want: resource.PropertyMap{
+				"applicationId": resource.NewStringProperty(guid),
+				"clientId":      resource.NewStringProperty(guid),
+				"id":            resource.NewStringProperty("/servicePrincipals/" + guid),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := migrateServicePrincipalState(context.Background(), tc.in)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Adds `TransformFromState` on `azuread_application` and `azuread_service_principal` to carry v5 state forward across two upstream v2→v3 changes:

- Backfills `clientId` from `applicationId` (the field rename).
- Prefixes bare-UUID `id` with `/applications/` or `/servicePrincipals/` (the id format change).

Upstream's state upgrader only handles the id rewrite and relies on the new `client_id` field being Computed-filled on the next API Read. Pulumi preview doesn't refresh, so dependent resources see undefined or unparseable values and fail Check before any update can run.

Fixes #2368 (clientId path). Fixes #1551 (id format path). 

Note that the longterm fix should be made via pulumi/pulumi-terraform-bridge#2676. Regardless, these transformations are cheap and unblock users today.