### PR TITLE
Fix UseCli Provider option and add OidcTokenFilePath support

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -8,6 +8,10 @@ import (
 	"os"
 	"path"
 	"testing"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
@@ -26,6 +30,43 @@ func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	})
 
 	return baseJS
+}
+
+func writeOIDCTokenToFile(path, audience string) error {
+	reqURL := os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL")
+	reqToken := os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+
+	if reqURL == "" || reqToken == "" {
+		return fmt.Errorf("GitHub OIDC environment variables not set")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, reqURL+"&audience="+audience, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+reqToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("OIDC request failed: %s: %s", resp.Status, body)
+	}
+
+	var r struct {
+		Value string `json:"value"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, []byte(r.Value), 0600)
 }
 
 func TestSimple(t *testing.T) {
@@ -54,6 +95,40 @@ func TestSimple_OIDC(t *testing.T) {
 				"ARM_USE_OIDC=true",
 				// not strictly necessary but making sure we test the OIDC path
 				"ARM_CLIENT_SECRET=",
+				"ARM_USE_CLI=false",
+			},
+			RunUpdateTest: true,
+			Secrets: map[string]string{
+				"password": "SecretP@sswd99!",
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
+// Testing oidc login with token file, this is the same as the above test but using a token file instead of env vars
+func TestSimple_OIDC_TOKEN_FILE(t *testing.T) {
+	if os.Getenv("RUN_OIDC_TESTS") != "true" {
+		t.Skip("Skipping OIDC test")
+	}
+
+	tokenFile := path.Join(getCwd(t), "simple", "token.jwt")
+
+	err := writeOIDCTokenToFile(tokenFile, "api://AzureADTokenExchange")
+	require.NoError(t, err)
+
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "simple"),
+			Env: []string{
+				"ARM_USE_OIDC=true",
+				"ARM_OIDC_TOKEN_FILE_PATH=token.jwt",
+				// not strictly necessary but making sure we test the OIDC path
+				"ARM_CLIENT_SECRET=",
+				"ARM_USE_CLI=false",
+				// explicatly clear to make sure we use the token from file
+				"ACTIONS_ID_TOKEN_REQUEST_URL=",
+				"ACTIONS_ID_TOKEN_REQUEST_TOKEN=",
 			},
 			RunUpdateTest: true,
 			Secrets: map[string]string{

--- a/provider/cmd/pulumi-resource-azuread/schema.json
+++ b/provider/cmd/pulumi-resource-azuread/schema.json
@@ -117,11 +117,23 @@
             },
             "oidcRequestToken": {
                 "type": "string",
-                "description": "The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID Connect."
+                "description": "The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID Connect.",
+                "defaultInfo": {
+                    "environment": [
+                        "ARM_OIDC_REQUEST_TOKEN",
+                        "ACTIONS_ID_TOKEN_REQUEST_TOKEN"
+                    ]
+                }
             },
             "oidcRequestUrl": {
                 "type": "string",
-                "description": "The URL for the OIDC provider from which to request an ID token. For use when authenticating as a Service Principal using OpenID Connect."
+                "description": "The URL for the OIDC provider from which to request an ID token. For use when authenticating as a Service Principal using OpenID Connect.",
+                "defaultInfo": {
+                    "environment": [
+                        "ARM_OIDC_REQUEST_URL",
+                        "ACTIONS_ID_TOKEN_REQUEST_URL "
+                    ]
+                }
             },
             "oidcToken": {
                 "type": "string",
@@ -129,7 +141,12 @@
             },
             "oidcTokenFilePath": {
                 "type": "string",
-                "description": "The path to a file containing an ID token for use when authenticating as a Service Principal using OpenID Connect."
+                "description": "The path to a file containing an ID token for use when authenticating as a Service Principal using OpenID Connect.",
+                "defaultInfo": {
+                    "environment": [
+                        "ARM_OIDC_TOKEN_FILE_PATH"
+                    ]
+                }
             },
             "partnerId": {
                 "type": "string",
@@ -145,7 +162,13 @@
             },
             "useCli": {
                 "type": "boolean",
-                "description": "Allow Azure CLI to be used for Authentication"
+                "description": "Allow Azure CLI to be used for Authentication",
+                "default": true,
+                "defaultInfo": {
+                    "environment": [
+                        "ARM_USE_CLI"
+                    ]
+                }
             },
             "useMsi": {
                 "type": "boolean",
@@ -159,7 +182,13 @@
             },
             "useOidc": {
                 "type": "boolean",
-                "description": "Allow OpenID Connect to be used for authentication"
+                "description": "Allow OpenID Connect to be used for authentication",
+                "default": false,
+                "defaultInfo": {
+                    "environment": [
+                        "ARM_USE_OIDC"
+                    ]
+                }
             }
         },
         "defaults": [
@@ -3271,11 +3300,23 @@
             },
             "oidcRequestToken": {
                 "type": "string",
-                "description": "The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID Connect."
+                "description": "The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID Connect.",
+                "defaultInfo": {
+                    "environment": [
+                        "ARM_OIDC_REQUEST_TOKEN",
+                        "ACTIONS_ID_TOKEN_REQUEST_TOKEN"
+                    ]
+                }
             },
             "oidcRequestUrl": {
                 "type": "string",
-                "description": "The URL for the OIDC provider from which to request an ID token. For use when authenticating as a Service Principal using OpenID Connect."
+                "description": "The URL for the OIDC provider from which to request an ID token. For use when authenticating as a Service Principal using OpenID Connect.",
+                "defaultInfo": {
+                    "environment": [
+                        "ARM_OIDC_REQUEST_URL",
+                        "ACTIONS_ID_TOKEN_REQUEST_URL "
+                    ]
+                }
             },
             "oidcToken": {
                 "type": "string",
@@ -3283,7 +3324,12 @@
             },
             "oidcTokenFilePath": {
                 "type": "string",
-                "description": "The path to a file containing an ID token for use when authenticating as a Service Principal using OpenID Connect."
+                "description": "The path to a file containing an ID token for use when authenticating as a Service Principal using OpenID Connect.",
+                "defaultInfo": {
+                    "environment": [
+                        "ARM_OIDC_TOKEN_FILE_PATH"
+                    ]
+                }
             },
             "partnerId": {
                 "type": "string",
@@ -3299,7 +3345,13 @@
             },
             "useCli": {
                 "type": "boolean",
-                "description": "Allow Azure CLI to be used for Authentication"
+                "description": "Allow Azure CLI to be used for Authentication",
+                "default": true,
+                "defaultInfo": {
+                    "environment": [
+                        "ARM_USE_CLI"
+                    ]
+                }
             },
             "useMsi": {
                 "type": "boolean",
@@ -3313,7 +3365,13 @@
             },
             "useOidc": {
                 "type": "boolean",
-                "description": "Allow OpenID Connect to be used for authentication"
+                "description": "Allow OpenID Connect to be used for authentication",
+                "default": false,
+                "defaultInfo": {
+                    "environment": [
+                        "ARM_USE_OIDC"
+                    ]
+                }
             }
         },
         "methods": {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -233,7 +233,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"use_cli": {
 				Default: &tfbridge.DefaultInfo{
-					Value:   false,
+					Value:   true,
 					EnvVars: []string{"ARM_USE_CLI"},
 				},
 			},
@@ -243,8 +243,26 @@ func Provider() tfbridge.ProviderInfo {
 					EnvVars: []string{"ARM_USE_MSI"},
 				},
 			},
+			"use_oidc": {
+				Default: &tfbridge.DefaultInfo{
+					Value:   false,
+					EnvVars: []string{"ARM_USE_OIDC"},
+				},
+			},
+			"oidc_request_token": {
+				Default: &tfbridge.DefaultInfo{
+					EnvVars: []string{"ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN"},
+				},
+			},
+			"oidc_request_url": {
+				Default: &tfbridge.DefaultInfo{
+					EnvVars: []string{"ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL "},
+				},				
+			},
 			"oidc_token_file_path": {
-				MarkAsOptional: tfbridge.True(),
+				Default: &tfbridge.DefaultInfo{
+					EnvVars: []string{"ARM_OIDC_TOKEN_FILE_PATH"},
+				},	
 			},
 		},
 		PreConfigureCallback: preConfigureCallback,

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -92,6 +93,22 @@ func preConfigureCallback(vars resource.PropertyMap, _ tfshim.ResourceConfig) er
 	}
 
 	useOIDC := tfbridge.ConfigBoolValue(vars, "useOidc", []string{"ARM_USE_OIDC"})
+	useCLI := tfbridge.ConfigBoolValue(vars, "useCli", []string{"ARM_USE_CLI"})
+	
+	// Handle OIDC token - prioritize file, then fallback to config value
+	var oidcToken string
+	oidcTokenFilePath := tfbridge.ConfigStringValue(vars, "oidcTokenFilePath", []string{"ARM_OIDC_TOKEN_FILE_PATH"})
+	if oidcTokenFilePath != "" {
+		tokenContent, err := os.ReadFile(oidcTokenFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to read OIDC token from file \"%s\": %v", oidcTokenFilePath, err)
+		}
+		oidcToken = string(bytes.TrimSpace(tokenContent))
+	} else {
+		// Fallback to oidcToken config if file path is not set
+		oidcToken = tfbridge.ConfigStringValue(vars, "oidcToken", []string{"ARM_OIDC_TOKEN"})
+	}
+	
 	authConfig := auth.Credentials{
 		Environment:        *env,
 		ClientID:           tfbridge.ConfigStringValue(vars, "clientId", []string{"ARM_CLIENT_ID"}),
@@ -108,13 +125,13 @@ func preConfigureCallback(vars resource.PropertyMap, _ tfshim.ResourceConfig) er
 		// OIDC section. The ACTIONS_ variables are set by GitHub.
 		OIDCTokenRequestToken: tfbridge.ConfigStringValue(vars, "oidcRequestToken", []string{"ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN"}),
 		OIDCTokenRequestURL:   tfbridge.ConfigStringValue(vars, "oidcRequestUrl", []string{"ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL"}),
-		OIDCAssertionToken:    tfbridge.ConfigStringValue(vars, "oidcToken", []string{"ARM_OIDC_TOKEN"}),
+		OIDCAssertionToken:    oidcToken,
 
 		// Feature Toggles
 		EnableAuthenticatingUsingClientCertificate: true,
 		EnableAuthenticatingUsingClientSecret:      true,
 		EnableAuthenticatingUsingManagedIdentity:   tfbridge.ConfigBoolValue(vars, "useMsi", []string{"ARM_USE_MSI"}),
-		EnableAuthenticatingUsingAzureCLI:          true,
+		EnableAuthenticatingUsingAzureCLI:          useCLI,
 		EnableAuthenticationUsingOIDC:              useOIDC,
 		EnableAuthenticationUsingGitHubOIDC:        useOIDC,
 	}
@@ -214,11 +231,20 @@ func Provider() tfbridge.ProviderInfo {
 					EnvVars: []string{"ARM_MSI_ENDPOINT"},
 				},
 			},
+			"use_cli": {
+				Default: &tfbridge.DefaultInfo{
+					Value:   false,
+					EnvVars: []string{"ARM_USE_CLI"},
+				},
+			},
 			"use_msi": {
 				Default: &tfbridge.DefaultInfo{
 					Value:   false,
 					EnvVars: []string{"ARM_USE_MSI"},
 				},
+			},
+			"oidc_token_file_path": {
+				MarkAsOptional: tfbridge.True(),
 			},
 		},
 		PreConfigureCallback: preConfigureCallback,

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -152,7 +152,7 @@ namespace Pulumi.AzureAD
             set => _msiEndpoint.Set(value);
         }
 
-        private static readonly __Value<string?> _oidcRequestToken = new __Value<string?>(() => __config.Get("oidcRequestToken"));
+        private static readonly __Value<string?> _oidcRequestToken = new __Value<string?>(() => __config.Get("oidcRequestToken") ?? Utilities.GetEnv("ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN"));
         /// <summary>
         /// The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID Connect.
         /// </summary>
@@ -162,7 +162,7 @@ namespace Pulumi.AzureAD
             set => _oidcRequestToken.Set(value);
         }
 
-        private static readonly __Value<string?> _oidcRequestUrl = new __Value<string?>(() => __config.Get("oidcRequestUrl"));
+        private static readonly __Value<string?> _oidcRequestUrl = new __Value<string?>(() => __config.Get("oidcRequestUrl") ?? Utilities.GetEnv("ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL "));
         /// <summary>
         /// The URL for the OIDC provider from which to request an ID token. For use when authenticating as a Service Principal using OpenID Connect.
         /// </summary>
@@ -182,7 +182,7 @@ namespace Pulumi.AzureAD
             set => _oidcToken.Set(value);
         }
 
-        private static readonly __Value<string?> _oidcTokenFilePath = new __Value<string?>(() => __config.Get("oidcTokenFilePath"));
+        private static readonly __Value<string?> _oidcTokenFilePath = new __Value<string?>(() => __config.Get("oidcTokenFilePath") ?? Utilities.GetEnv("ARM_OIDC_TOKEN_FILE_PATH"));
         /// <summary>
         /// The path to a file containing an ID token for use when authenticating as a Service Principal using OpenID Connect.
         /// </summary>
@@ -222,7 +222,7 @@ namespace Pulumi.AzureAD
             set => _useAksWorkloadIdentity.Set(value);
         }
 
-        private static readonly __Value<bool?> _useCli = new __Value<bool?>(() => __config.GetBoolean("useCli"));
+        private static readonly __Value<bool?> _useCli = new __Value<bool?>(() => __config.GetBoolean("useCli") ?? Utilities.GetEnvBoolean("ARM_USE_CLI") ?? true);
         /// <summary>
         /// Allow Azure CLI to be used for Authentication
         /// </summary>
@@ -242,7 +242,7 @@ namespace Pulumi.AzureAD
             set => _useMsi.Set(value);
         }
 
-        private static readonly __Value<bool?> _useOidc = new __Value<bool?>(() => __config.GetBoolean("useOidc"));
+        private static readonly __Value<bool?> _useOidc = new __Value<bool?>(() => __config.GetBoolean("useOidc") ?? Utilities.GetEnvBoolean("ARM_USE_OIDC") ?? false);
         /// <summary>
         /// Allow OpenID Connect to be used for authentication
         /// </summary>

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -326,7 +326,12 @@ namespace Pulumi.AzureAD
         {
             Environment = Utilities.GetEnv("ARM_ENVIRONMENT") ?? "public";
             MsiEndpoint = Utilities.GetEnv("ARM_MSI_ENDPOINT");
+            OidcRequestToken = Utilities.GetEnv("ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN");
+            OidcRequestUrl = Utilities.GetEnv("ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL ");
+            OidcTokenFilePath = Utilities.GetEnv("ARM_OIDC_TOKEN_FILE_PATH");
+            UseCli = Utilities.GetEnvBoolean("ARM_USE_CLI") ?? true;
             UseMsi = Utilities.GetEnvBoolean("ARM_USE_MSI") ?? false;
+            UseOidc = Utilities.GetEnvBoolean("ARM_USE_OIDC") ?? false;
         }
         public static new ProviderArgs Empty => new ProviderArgs();
     }

--- a/sdk/go/azuread/config/config.go
+++ b/sdk/go/azuread/config/config.go
@@ -89,12 +89,28 @@ func GetMsiEndpoint(ctx *pulumi.Context) string {
 
 // The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID Connect.
 func GetOidcRequestToken(ctx *pulumi.Context) string {
-	return config.Get(ctx, "azuread:oidcRequestToken")
+	v, err := config.Try(ctx, "azuread:oidcRequestToken")
+	if err == nil {
+		return v
+	}
+	var value string
+	if d := internal.GetEnvOrDefault(nil, nil, "ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN"); d != nil {
+		value = d.(string)
+	}
+	return value
 }
 
 // The URL for the OIDC provider from which to request an ID token. For use when authenticating as a Service Principal using OpenID Connect.
 func GetOidcRequestUrl(ctx *pulumi.Context) string {
-	return config.Get(ctx, "azuread:oidcRequestUrl")
+	v, err := config.Try(ctx, "azuread:oidcRequestUrl")
+	if err == nil {
+		return v
+	}
+	var value string
+	if d := internal.GetEnvOrDefault(nil, nil, "ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL "); d != nil {
+		value = d.(string)
+	}
+	return value
 }
 
 // The ID token for use when authenticating as a Service Principal using OpenID Connect.
@@ -104,7 +120,15 @@ func GetOidcToken(ctx *pulumi.Context) string {
 
 // The path to a file containing an ID token for use when authenticating as a Service Principal using OpenID Connect.
 func GetOidcTokenFilePath(ctx *pulumi.Context) string {
-	return config.Get(ctx, "azuread:oidcTokenFilePath")
+	v, err := config.Try(ctx, "azuread:oidcTokenFilePath")
+	if err == nil {
+		return v
+	}
+	var value string
+	if d := internal.GetEnvOrDefault(nil, nil, "ARM_OIDC_TOKEN_FILE_PATH"); d != nil {
+		value = d.(string)
+	}
+	return value
 }
 
 // A GUID/UUID that is registered with Microsoft to facilitate partner resource usage attribution
@@ -124,7 +148,15 @@ func GetUseAksWorkloadIdentity(ctx *pulumi.Context) bool {
 
 // Allow Azure CLI to be used for Authentication
 func GetUseCli(ctx *pulumi.Context) bool {
-	return config.GetBool(ctx, "azuread:useCli")
+	v, err := config.TryBool(ctx, "azuread:useCli")
+	if err == nil {
+		return v
+	}
+	var value bool
+	if d := internal.GetEnvOrDefault(true, internal.ParseEnvBool, "ARM_USE_CLI"); d != nil {
+		value = d.(bool)
+	}
+	return value
 }
 
 // Allow Managed Identity to be used for Authentication
@@ -142,5 +174,13 @@ func GetUseMsi(ctx *pulumi.Context) bool {
 
 // Allow OpenID Connect to be used for authentication
 func GetUseOidc(ctx *pulumi.Context) bool {
-	return config.GetBool(ctx, "azuread:useOidc")
+	v, err := config.TryBool(ctx, "azuread:useOidc")
+	if err == nil {
+		return v
+	}
+	var value bool
+	if d := internal.GetEnvOrDefault(false, internal.ParseEnvBool, "ARM_USE_OIDC"); d != nil {
+		value = d.(bool)
+	}
+	return value
 }

--- a/sdk/go/azuread/provider.go
+++ b/sdk/go/azuread/provider.go
@@ -71,9 +71,34 @@ func NewProvider(ctx *pulumi.Context,
 			args.MsiEndpoint = pulumi.StringPtr(d.(string))
 		}
 	}
+	if args.OidcRequestToken == nil {
+		if d := internal.GetEnvOrDefault(nil, nil, "ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN"); d != nil {
+			args.OidcRequestToken = pulumi.StringPtr(d.(string))
+		}
+	}
+	if args.OidcRequestUrl == nil {
+		if d := internal.GetEnvOrDefault(nil, nil, "ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL "); d != nil {
+			args.OidcRequestUrl = pulumi.StringPtr(d.(string))
+		}
+	}
+	if args.OidcTokenFilePath == nil {
+		if d := internal.GetEnvOrDefault(nil, nil, "ARM_OIDC_TOKEN_FILE_PATH"); d != nil {
+			args.OidcTokenFilePath = pulumi.StringPtr(d.(string))
+		}
+	}
+	if args.UseCli == nil {
+		if d := internal.GetEnvOrDefault(true, internal.ParseEnvBool, "ARM_USE_CLI"); d != nil {
+			args.UseCli = pulumi.BoolPtr(d.(bool))
+		}
+	}
 	if args.UseMsi == nil {
 		if d := internal.GetEnvOrDefault(false, internal.ParseEnvBool, "ARM_USE_MSI"); d != nil {
 			args.UseMsi = pulumi.BoolPtr(d.(bool))
+		}
+	}
+	if args.UseOidc == nil {
+		if d := internal.GetEnvOrDefault(false, internal.ParseEnvBool, "ARM_USE_OIDC"); d != nil {
+			args.UseOidc = pulumi.BoolPtr(d.(bool))
 		}
 	}
 	if args.ClientCertificatePassword != nil {

--- a/sdk/java/src/main/java/com/pulumi/azuread/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/azuread/Config.java
@@ -100,14 +100,14 @@ public final class Config {
  * 
  */
     public Optional<String> oidcRequestToken() {
-        return Codegen.stringProp("oidcRequestToken").config(config).get();
+        return Codegen.stringProp("oidcRequestToken").config(config).env("ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN").get();
     }
 /**
  * The URL for the OIDC provider from which to request an ID token. For use when authenticating as a Service Principal using OpenID Connect.
  * 
  */
     public Optional<String> oidcRequestUrl() {
-        return Codegen.stringProp("oidcRequestUrl").config(config).get();
+        return Codegen.stringProp("oidcRequestUrl").config(config).env("ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL ").get();
     }
 /**
  * The ID token for use when authenticating as a Service Principal using OpenID Connect.
@@ -121,7 +121,7 @@ public final class Config {
  * 
  */
     public Optional<String> oidcTokenFilePath() {
-        return Codegen.stringProp("oidcTokenFilePath").config(config).get();
+        return Codegen.stringProp("oidcTokenFilePath").config(config).env("ARM_OIDC_TOKEN_FILE_PATH").get();
     }
 /**
  * A GUID/UUID that is registered with Microsoft to facilitate partner resource usage attribution
@@ -149,7 +149,7 @@ public final class Config {
  * 
  */
     public Optional<Boolean> useCli() {
-        return Codegen.booleanProp("useCli").config(config).get();
+        return Codegen.booleanProp("useCli").config(config).env("ARM_USE_CLI").def(true).get();
     }
 /**
  * Allow Managed Identity to be used for Authentication
@@ -163,6 +163,6 @@ public final class Config {
  * 
  */
     public Optional<Boolean> useOidc() {
-        return Codegen.booleanProp("useOidc").config(config).get();
+        return Codegen.booleanProp("useOidc").config(config).env("ARM_USE_OIDC").def(false).get();
     }
 }

--- a/sdk/java/src/main/java/com/pulumi/azuread/ProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/azuread/ProviderArgs.java
@@ -857,7 +857,12 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         public ProviderArgs build() {
             $.environment = Codegen.stringProp("environment").output().arg($.environment).env("ARM_ENVIRONMENT").def("public").getNullable();
             $.msiEndpoint = Codegen.stringProp("msiEndpoint").output().arg($.msiEndpoint).env("ARM_MSI_ENDPOINT").getNullable();
+            $.oidcRequestToken = Codegen.stringProp("oidcRequestToken").output().arg($.oidcRequestToken).env("ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN").getNullable();
+            $.oidcRequestUrl = Codegen.stringProp("oidcRequestUrl").output().arg($.oidcRequestUrl).env("ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL ").getNullable();
+            $.oidcTokenFilePath = Codegen.stringProp("oidcTokenFilePath").output().arg($.oidcTokenFilePath).env("ARM_OIDC_TOKEN_FILE_PATH").getNullable();
+            $.useCli = Codegen.booleanProp("useCli").output().arg($.useCli).env("ARM_USE_CLI").def(true).getNullable();
             $.useMsi = Codegen.booleanProp("useMsi").output().arg($.useMsi).env("ARM_USE_MSI").def(false).getNullable();
+            $.useOidc = Codegen.booleanProp("useOidc").output().arg($.useOidc).env("ARM_USE_OIDC").def(false).getNullable();
             return $;
         }
     }

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -145,7 +145,7 @@ Object.defineProperty(exports, "msiEndpoint", {
 export declare const oidcRequestToken: string | undefined;
 Object.defineProperty(exports, "oidcRequestToken", {
     get() {
-        return __config.get("oidcRequestToken");
+        return __config.get("oidcRequestToken") ?? utilities.getEnv("ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN");
     },
     enumerable: true,
 });
@@ -156,7 +156,7 @@ Object.defineProperty(exports, "oidcRequestToken", {
 export declare const oidcRequestUrl: string | undefined;
 Object.defineProperty(exports, "oidcRequestUrl", {
     get() {
-        return __config.get("oidcRequestUrl");
+        return __config.get("oidcRequestUrl") ?? utilities.getEnv("ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL ");
     },
     enumerable: true,
 });
@@ -178,7 +178,7 @@ Object.defineProperty(exports, "oidcToken", {
 export declare const oidcTokenFilePath: string | undefined;
 Object.defineProperty(exports, "oidcTokenFilePath", {
     get() {
-        return __config.get("oidcTokenFilePath");
+        return __config.get("oidcTokenFilePath") ?? utilities.getEnv("ARM_OIDC_TOKEN_FILE_PATH");
     },
     enumerable: true,
 });
@@ -219,10 +219,10 @@ Object.defineProperty(exports, "useAksWorkloadIdentity", {
 /**
  * Allow Azure CLI to be used for Authentication
  */
-export declare const useCli: boolean | undefined;
+export declare const useCli: boolean;
 Object.defineProperty(exports, "useCli", {
     get() {
-        return __config.getObject<boolean>("useCli");
+        return __config.getObject<boolean>("useCli") ?? (utilities.getEnvBoolean("ARM_USE_CLI") || true);
     },
     enumerable: true,
 });
@@ -241,10 +241,10 @@ Object.defineProperty(exports, "useMsi", {
 /**
  * Allow OpenID Connect to be used for authentication
  */
-export declare const useOidc: boolean | undefined;
+export declare const useOidc: boolean;
 Object.defineProperty(exports, "useOidc", {
     get() {
-        return __config.getObject<boolean>("useOidc");
+        return __config.getObject<boolean>("useOidc") ?? (utilities.getEnvBoolean("ARM_USE_OIDC") || false);
     },
     enumerable: true,
 });

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -117,16 +117,16 @@ export class Provider extends pulumi.ProviderResource {
             resourceInputs["environment"] = (args?.environment) ?? (utilities.getEnv("ARM_ENVIRONMENT") || "public");
             resourceInputs["metadataHost"] = args?.metadataHost;
             resourceInputs["msiEndpoint"] = (args?.msiEndpoint) ?? utilities.getEnv("ARM_MSI_ENDPOINT");
-            resourceInputs["oidcRequestToken"] = args?.oidcRequestToken;
-            resourceInputs["oidcRequestUrl"] = args?.oidcRequestUrl;
+            resourceInputs["oidcRequestToken"] = (args?.oidcRequestToken) ?? utilities.getEnv("ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN");
+            resourceInputs["oidcRequestUrl"] = (args?.oidcRequestUrl) ?? utilities.getEnv("ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL ");
             resourceInputs["oidcToken"] = args?.oidcToken;
-            resourceInputs["oidcTokenFilePath"] = args?.oidcTokenFilePath;
+            resourceInputs["oidcTokenFilePath"] = (args?.oidcTokenFilePath) ?? utilities.getEnv("ARM_OIDC_TOKEN_FILE_PATH");
             resourceInputs["partnerId"] = args?.partnerId;
             resourceInputs["tenantId"] = args?.tenantId;
             resourceInputs["useAksWorkloadIdentity"] = pulumi.output(args?.useAksWorkloadIdentity).apply(JSON.stringify);
-            resourceInputs["useCli"] = pulumi.output(args?.useCli).apply(JSON.stringify);
+            resourceInputs["useCli"] = pulumi.output((args?.useCli) ?? (utilities.getEnvBoolean("ARM_USE_CLI") || true)).apply(JSON.stringify);
             resourceInputs["useMsi"] = pulumi.output((args?.useMsi) ?? (utilities.getEnvBoolean("ARM_USE_MSI") || false)).apply(JSON.stringify);
-            resourceInputs["useOidc"] = pulumi.output(args?.useOidc).apply(JSON.stringify);
+            resourceInputs["useOidc"] = pulumi.output((args?.useOidc) ?? (utilities.getEnvBoolean("ARM_USE_OIDC") || false)).apply(JSON.stringify);
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const secretOpts = { additionalSecretOutputs: ["clientCertificatePassword", "clientId", "clientSecret"] };

--- a/sdk/python/pulumi_azuread/config/__init__.pyi
+++ b/sdk/python/pulumi_azuread/config/__init__.pyi
@@ -109,7 +109,7 @@ useAksWorkloadIdentity: Optional[bool]
 Allow Azure AKS Workload Identity to be used for Authentication.
 """
 
-useCli: Optional[bool]
+useCli: bool
 """
 Allow Azure CLI to be used for Authentication
 """
@@ -119,7 +119,7 @@ useMsi: bool
 Allow Managed Identity to be used for Authentication
 """
 
-useOidc: Optional[bool]
+useOidc: bool
 """
 Allow OpenID Connect to be used for authentication
 """

--- a/sdk/python/pulumi_azuread/config/vars.py
+++ b/sdk/python/pulumi_azuread/config/vars.py
@@ -109,14 +109,14 @@ class _ExportableConfig(types.ModuleType):
         """
         The bearer token for the request to the OIDC provider. For use when authenticating as a Service Principal using OpenID Connect.
         """
-        return __config__.get('oidcRequestToken')
+        return __config__.get('oidcRequestToken') or _utilities.get_env('ARM_OIDC_REQUEST_TOKEN', 'ACTIONS_ID_TOKEN_REQUEST_TOKEN')
 
     @_builtins.property
     def oidc_request_url(self) -> Optional[str]:
         """
         The URL for the OIDC provider from which to request an ID token. For use when authenticating as a Service Principal using OpenID Connect.
         """
-        return __config__.get('oidcRequestUrl')
+        return __config__.get('oidcRequestUrl') or _utilities.get_env('ARM_OIDC_REQUEST_URL', 'ACTIONS_ID_TOKEN_REQUEST_URL ')
 
     @_builtins.property
     def oidc_token(self) -> Optional[str]:
@@ -130,7 +130,7 @@ class _ExportableConfig(types.ModuleType):
         """
         The path to a file containing an ID token for use when authenticating as a Service Principal using OpenID Connect.
         """
-        return __config__.get('oidcTokenFilePath')
+        return __config__.get('oidcTokenFilePath') or _utilities.get_env('ARM_OIDC_TOKEN_FILE_PATH')
 
     @_builtins.property
     def partner_id(self) -> Optional[str]:
@@ -154,11 +154,11 @@ class _ExportableConfig(types.ModuleType):
         return __config__.get_bool('useAksWorkloadIdentity')
 
     @_builtins.property
-    def use_cli(self) -> Optional[bool]:
+    def use_cli(self) -> bool:
         """
         Allow Azure CLI to be used for Authentication
         """
-        return __config__.get_bool('useCli')
+        return __config__.get_bool('useCli') or (_utilities.get_env_bool('ARM_USE_CLI') or True)
 
     @_builtins.property
     def use_msi(self) -> bool:
@@ -168,9 +168,9 @@ class _ExportableConfig(types.ModuleType):
         return __config__.get_bool('useMsi') or (_utilities.get_env_bool('ARM_USE_MSI') or False)
 
     @_builtins.property
-    def use_oidc(self) -> Optional[bool]:
+    def use_oidc(self) -> bool:
         """
         Allow OpenID Connect to be used for authentication
         """
-        return __config__.get_bool('useOidc')
+        return __config__.get_bool('useOidc') or (_utilities.get_env_bool('ARM_USE_OIDC') or False)
 

--- a/sdk/python/pulumi_azuread/provider.py
+++ b/sdk/python/pulumi_azuread/provider.py
@@ -95,12 +95,18 @@ class ProviderArgs:
             msi_endpoint = _utilities.get_env('ARM_MSI_ENDPOINT')
         if msi_endpoint is not None:
             pulumi.set(__self__, "msi_endpoint", msi_endpoint)
+        if oidc_request_token is None:
+            oidc_request_token = _utilities.get_env('ARM_OIDC_REQUEST_TOKEN', 'ACTIONS_ID_TOKEN_REQUEST_TOKEN')
         if oidc_request_token is not None:
             pulumi.set(__self__, "oidc_request_token", oidc_request_token)
+        if oidc_request_url is None:
+            oidc_request_url = _utilities.get_env('ARM_OIDC_REQUEST_URL', 'ACTIONS_ID_TOKEN_REQUEST_URL ')
         if oidc_request_url is not None:
             pulumi.set(__self__, "oidc_request_url", oidc_request_url)
         if oidc_token is not None:
             pulumi.set(__self__, "oidc_token", oidc_token)
+        if oidc_token_file_path is None:
+            oidc_token_file_path = _utilities.get_env('ARM_OIDC_TOKEN_FILE_PATH')
         if oidc_token_file_path is not None:
             pulumi.set(__self__, "oidc_token_file_path", oidc_token_file_path)
         if partner_id is not None:
@@ -109,12 +115,16 @@ class ProviderArgs:
             pulumi.set(__self__, "tenant_id", tenant_id)
         if use_aks_workload_identity is not None:
             pulumi.set(__self__, "use_aks_workload_identity", use_aks_workload_identity)
+        if use_cli is None:
+            use_cli = (_utilities.get_env_bool('ARM_USE_CLI') or True)
         if use_cli is not None:
             pulumi.set(__self__, "use_cli", use_cli)
         if use_msi is None:
             use_msi = (_utilities.get_env_bool('ARM_USE_MSI') or False)
         if use_msi is not None:
             pulumi.set(__self__, "use_msi", use_msi)
+        if use_oidc is None:
+            use_oidc = (_utilities.get_env_bool('ARM_USE_OIDC') or False)
         if use_oidc is not None:
             pulumi.set(__self__, "use_oidc", use_oidc)
 
@@ -519,17 +529,27 @@ class Provider(pulumi.ProviderResource):
             if msi_endpoint is None:
                 msi_endpoint = _utilities.get_env('ARM_MSI_ENDPOINT')
             __props__.__dict__["msi_endpoint"] = msi_endpoint
+            if oidc_request_token is None:
+                oidc_request_token = _utilities.get_env('ARM_OIDC_REQUEST_TOKEN', 'ACTIONS_ID_TOKEN_REQUEST_TOKEN')
             __props__.__dict__["oidc_request_token"] = oidc_request_token
+            if oidc_request_url is None:
+                oidc_request_url = _utilities.get_env('ARM_OIDC_REQUEST_URL', 'ACTIONS_ID_TOKEN_REQUEST_URL ')
             __props__.__dict__["oidc_request_url"] = oidc_request_url
             __props__.__dict__["oidc_token"] = oidc_token
+            if oidc_token_file_path is None:
+                oidc_token_file_path = _utilities.get_env('ARM_OIDC_TOKEN_FILE_PATH')
             __props__.__dict__["oidc_token_file_path"] = oidc_token_file_path
             __props__.__dict__["partner_id"] = partner_id
             __props__.__dict__["tenant_id"] = tenant_id
             __props__.__dict__["use_aks_workload_identity"] = pulumi.Output.from_input(use_aks_workload_identity).apply(pulumi.runtime.to_json) if use_aks_workload_identity is not None else None
+            if use_cli is None:
+                use_cli = (_utilities.get_env_bool('ARM_USE_CLI') or True)
             __props__.__dict__["use_cli"] = pulumi.Output.from_input(use_cli).apply(pulumi.runtime.to_json) if use_cli is not None else None
             if use_msi is None:
                 use_msi = (_utilities.get_env_bool('ARM_USE_MSI') or False)
             __props__.__dict__["use_msi"] = pulumi.Output.from_input(use_msi).apply(pulumi.runtime.to_json) if use_msi is not None else None
+            if use_oidc is None:
+                use_oidc = (_utilities.get_env_bool('ARM_USE_OIDC') or False)
             __props__.__dict__["use_oidc"] = pulumi.Output.from_input(use_oidc).apply(pulumi.runtime.to_json) if use_oidc is not None else None
         secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["clientCertificatePassword", "clientId", "clientSecret"])
         opts = pulumi.ResourceOptions.merge(opts, secret_opts)


### PR DESCRIPTION
This PR addresses the following
- Make EnableAuthenticatingUsingAzureCLI configurable via 'useCli' config option (defaults to false)
- Add support for 'oidcTokenFilePath' to read OIDC token from a file
  - Only read OIDC token from file if oidcTokenFilePath is explicitly set
 - Implement proper OIDC token priority: file > config value > null


- Add missing environment variable mappings for provider options


Tested with the following Program:

```yaml
name: odic-test
runtime: yaml
description: Testing oidc based azure ad access
plugins:
  providers:
  - name: azuread
    path: ../../../bin
resources:
  provider:
    type: pulumi:providers:azuread
    properties:
      tenantId: 782ec77f-9ccb-459d-92e1-54379945c7ac
      clientId: 59faa1b4-10de-4bc9-a70e-319de51fe161
      useCli: false
      useOidc: true
      oidcTokenFilePath: "oidctoken.jwt"
  example:
    type: azuread:Application
    properties:
      displayName: Example Application
      description: My example application
      signInAudience: AzureADMyOrg
      owners:
      - ${current.objectId}
    options:
      provider: ${provider}
variables:
  current:
    fn::invoke:
      function: azuread:getClientConfig
      arguments: {}
      options:
        provider: ${provider}
outputs:
  objectId: ${current.objectId}
```

Added a test next to the existing oidc test which pulls the token to file and uses this on the provider

Fixes: https://github.com/pulumi/pulumi-azuread/issues/2430
