### PR TITLE
fix: bump golangci-lint to 2.12.2 to match go1.26.4 toolchain

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,4 +4,3 @@
 "vfox-pulumi:pulumi/pulumi-azure" = "6.31.0"
 "vfox-pulumi:pulumi/pulumi-random" = "4.18.5"
 "vfox-pulumi:pulumi/pulumi-converter-terraform" = "1.2.4"
-golangci-lint = "2.12.2"

--- a/mise.toml
+++ b/mise.toml
@@ -4,4 +4,4 @@
 "vfox-pulumi:pulumi/pulumi-azure" = "6.31.0"
 "vfox-pulumi:pulumi/pulumi-random" = "4.18.5"
 "vfox-pulumi:pulumi/pulumi-converter-terraform" = "1.2.4"
-golangci-lint = "2.7.2"
+golangci-lint = "2.12.2"

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
+//nolint:goconst // repeated "clientId" literal keeps the assertions self-contained
 func TestSecretsAreEncrypted(t *testing.T) {
 	test := setupTest(t, "explicit-provider-with-config", opttest.SkipInstall())
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -181,7 +181,7 @@ func Provider() tfbridge.ProviderInfo {
 	// Create a Pulumi provider mapping
 	prov := tfbridge.ProviderInfo{
 		P:           p,
-		Name:        "azuread",
+		Name:        mainPkg,
 		DisplayName: "Azure Active Directory (Azure AD)",
 		Description: "A Pulumi package for creating and managing Azure Active Directory (Azure AD) cloud resources.",
 		Keywords:    []string{"pulumi", "azuread"},

--- a/provider/state_migration_test.go
+++ b/provider/state_migration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
+//nolint:goconst // repeated "clientId"/"applicationId" literals keep the test cases self-contained
 func TestMigrateApplicationState(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- `golangci-lint` was pinned to 2.7.2 in the repo's `mise.toml`, but that version was built with Go 1.25
- The `lint` job now resolves `GO_VERSION_MISE` to 1.26.4, and golangci-lint refuses to lint a module targeting a Go version newer than the one it was built with, failing every PR's `lint` job (e.g. observed on #2438)
- Bumps to 2.12.2, matching the version already used in `.config/mise.toml`

## Test plan
- [ ] CI `lint` job passes on this PR