### PR TITLE
Fix OIDC token-file and CLI preconfiguration

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -5,9 +5,16 @@
 package examples
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
@@ -26,6 +33,42 @@ func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	})
 
 	return baseJS
+}
+
+func oidcToken(t *testing.T) string {
+	t.Helper()
+
+	if token := os.Getenv("ARM_OIDC_TOKEN"); token != "" {
+		return token
+	}
+
+	requestURL := os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL")
+	requestToken := os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+	require.NotEmpty(t, requestURL, "RUN_OIDC_TESTS requires ACTIONS_ID_TOKEN_REQUEST_URL")
+	require.NotEmpty(t, requestToken, "RUN_OIDC_TESTS requires ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+
+	parsedURL, err := url.Parse(requestURL)
+	require.NoError(t, err)
+	query := parsedURL.Query()
+	query.Set("audience", "api://AzureADTokenExchange")
+	parsedURL.RawQuery = query.Encode()
+
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, parsedURL.String(), nil)
+	require.NoError(t, err)
+	request.Header.Set("Authorization", "Bearer "+requestToken)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	response, err := client.Do(request)
+	require.NoError(t, err)
+	defer response.Body.Close()
+
+	require.Equal(t, http.StatusOK, response.StatusCode, "GitHub OIDC token request failed: %s", response.Status)
+	var result struct {
+		Value string `json:"value"`
+	}
+	require.NoError(t, json.NewDecoder(response.Body).Decode(&result))
+	require.NotEmpty(t, result.Value)
+	return result.Value
 }
 
 func TestSimple(t *testing.T) {
@@ -52,10 +95,58 @@ func TestSimple_OIDC(t *testing.T) {
 			Dir: path.Join(getCwd(t), "simple"),
 			Env: []string{
 				"ARM_USE_OIDC=true",
+				"ARM_USE_CLI=false",
 				// not strictly necessary but making sure we test the OIDC path
 				"ARM_CLIENT_SECRET=",
 			},
 			RunUpdateTest: true,
+			Secrets: map[string]string{
+				"password": "SecretP@sswd99!",
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
+func TestSimple_OIDC_TokenFile(t *testing.T) {
+	if os.Getenv("RUN_OIDC_TESTS") != "true" {
+		t.Skip("Skipping OIDC test without OIDC_ARM_CLIENT_ID")
+	}
+
+	tokenPath := filepath.Join(t.TempDir(), "oidc-token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte(oidcToken(t)), 0o600))
+
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:                    path.Join(getCwd(t), "simple"),
+			NoParallel:             true,
+			SkipUpdate:             true,
+			SkipRefresh:            true,
+			SkipExportImport:       true,
+			SkipEmptyPreviewUpdate: true,
+			Env: []string{
+				"ARM_USE_OIDC=true",
+				"ARM_USE_CLI=false",
+				"ARM_USE_MSI=false",
+				"ARM_USE_AKS_WORKLOAD_IDENTITY=false",
+				"ARM_OIDC_TOKEN_FILE_PATH=" + tokenPath,
+				"ARM_OIDC_TOKEN=",
+				"ARM_OIDC_REQUEST_TOKEN=",
+				"ARM_OIDC_REQUEST_URL=",
+				"ACTIONS_ID_TOKEN_REQUEST_TOKEN=",
+				"ACTIONS_ID_TOKEN_REQUEST_URL=",
+				"SYSTEM_ACCESSTOKEN=",
+				"SYSTEM_OIDCREQUESTURI=",
+				"ARM_ADO_PIPELINE_SERVICE_CONNECTION_ID=",
+				"ARM_OIDC_AZURE_SERVICE_CONNECTION_ID=",
+				"ARM_CLIENT_CERTIFICATE=",
+				"ARM_CLIENT_CERTIFICATE_PATH=",
+				"ARM_CLIENT_CERTIFICATE_PASSWORD=",
+				"ARM_CLIENT_SECRET_FILE_PATH=",
+				"ARM_MSI_ENDPOINT=",
+				// not strictly necessary but making sure we test the OIDC path
+				"ARM_CLIENT_SECRET=",
+			},
 			Secrets: map[string]string{
 				"password": "SecretP@sswd99!",
 			},

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -18,8 +18,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -46,6 +48,13 @@ const (
 	mainPkg = "azuread"
 	// modules:
 	mainMod = "index" // the y module
+
+	armUseCLIEnv       = "ARM_USE_CLI"
+	clientIDConfigKey  = "clientId"
+	oidcTokenConfigKey = "oidcToken"
+	// This is a provider configuration key, not a credential.
+	oidcTokenFilePathConfigKey = "oidcTokenFilePath" //nolint:gosec
+	useCLIConfigKey            = "useCli"
 )
 
 // makeMember manufactures a type token for the package and the given module and type.
@@ -77,24 +86,75 @@ func makeResource(mod string, res string) tokens.Type {
 // managedByPulumi is a default used for some managed resources, in the absence of something more meaningful.
 // var managedByPulumi = &tfbridge.DefaultInfo{Value: "Managed by Pulumi"}
 
-// preConfigureCallback returns an error when cloud provider setup is misconfigured
+func configBoolValue(
+	vars resource.PropertyMap,
+	prop resource.PropertyKey,
+	envs []string,
+	defaultValue bool,
+) (bool, error) {
+	if value, ok := vars[prop]; ok && value.IsBool() {
+		return value.BoolValue(), nil
+	}
+
+	for _, env := range envs {
+		if value := os.Getenv(env); value != "" {
+			parsed, err := strconv.ParseBool(value)
+			if err != nil {
+				return false, fmt.Errorf("parsing %s as a boolean: %w", env, err)
+			}
+			return parsed, nil
+		}
+	}
+
+	return defaultValue, nil
+}
+
+// getOIDCToken matches the upstream provider's handling of oidc_token and oidc_token_file_path.
+func getOIDCToken(vars resource.PropertyMap) (string, error) {
+	token := tfbridge.ConfigStringValue(vars, oidcTokenConfigKey, []string{"ARM_OIDC_TOKEN"})
+	tokenFilePath := tfbridge.ConfigStringValue(
+		vars,
+		oidcTokenFilePathConfigKey,
+		[]string{"ARM_OIDC_TOKEN_FILE_PATH"},
+	)
+	if tokenFilePath == "" {
+		return token, nil
+	}
+
+	contents, err := os.ReadFile(tokenFilePath)
+	if err != nil {
+		return "", fmt.Errorf("reading OIDC token from file %q: %w", tokenFilePath, err)
+	}
+
+	fileToken := string(bytes.TrimSpace(contents))
+	if token != "" && token != fileToken {
+		return "", fmt.Errorf(
+			"mismatch between supplied OIDC token and supplied OIDC token file contents - " +
+				"please either remove one or ensure they match",
+		)
+	}
+
+	return fileToken, nil
+}
+
+// getAuthConfig builds the credentials used by the Pulumi-specific pre-configuration check.
 //
 // nolint: lll
-func preConfigureCallback(vars resource.PropertyMap, _ tfshim.ResourceConfig) error {
-	envName := tfbridge.ConfigStringValue(vars, "environment", []string{"ARM_ENVIRONMENT"})
-	if envName == "" {
-		envName = "public"
-	}
-
-	env, err := environments.FromName(envName)
-	if err != nil {
-		return fmt.Errorf("failed to read Azure environment \"%s\": %v", envName, err)
-	}
-
+func getAuthConfig(vars resource.PropertyMap, environment environments.Environment) (auth.Credentials, error) {
 	useOIDC := tfbridge.ConfigBoolValue(vars, "useOidc", []string{"ARM_USE_OIDC"})
-	authConfig := auth.Credentials{
-		Environment:        *env,
-		ClientID:           tfbridge.ConfigStringValue(vars, "clientId", []string{"ARM_CLIENT_ID"}),
+	useCLI, err := configBoolValue(vars, useCLIConfigKey, []string{armUseCLIEnv}, true)
+	if err != nil {
+		return auth.Credentials{}, err
+	}
+
+	oidcToken, err := getOIDCToken(vars)
+	if err != nil {
+		return auth.Credentials{}, err
+	}
+
+	return auth.Credentials{
+		Environment:        environment,
+		ClientID:           tfbridge.ConfigStringValue(vars, clientIDConfigKey, []string{"ARM_CLIENT_ID"}),
 		ClientSecret:       tfbridge.ConfigStringValue(vars, "clientSecret", []string{"ARM_CLIENT_SECRET"}),
 		TenantID:           tfbridge.ConfigStringValue(vars, "tenantId", []string{"ARM_TENANT_ID"}),
 		AuxiliaryTenantIDs: tfbridge.ConfigArrayValue(vars, "auxiliaryTenantIDs", []string{"ARM_AUXILIARY_TENANT_IDS"}),
@@ -108,15 +168,33 @@ func preConfigureCallback(vars resource.PropertyMap, _ tfshim.ResourceConfig) er
 		// OIDC section. The ACTIONS_ variables are set by GitHub.
 		OIDCTokenRequestToken: tfbridge.ConfigStringValue(vars, "oidcRequestToken", []string{"ARM_OIDC_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_TOKEN"}),
 		OIDCTokenRequestURL:   tfbridge.ConfigStringValue(vars, "oidcRequestUrl", []string{"ARM_OIDC_REQUEST_URL", "ACTIONS_ID_TOKEN_REQUEST_URL"}),
-		OIDCAssertionToken:    tfbridge.ConfigStringValue(vars, "oidcToken", []string{"ARM_OIDC_TOKEN"}),
+		OIDCAssertionToken:    oidcToken,
 
 		// Feature Toggles
 		EnableAuthenticatingUsingClientCertificate: true,
 		EnableAuthenticatingUsingClientSecret:      true,
 		EnableAuthenticatingUsingManagedIdentity:   tfbridge.ConfigBoolValue(vars, "useMsi", []string{"ARM_USE_MSI"}),
-		EnableAuthenticatingUsingAzureCLI:          true,
+		EnableAuthenticatingUsingAzureCLI:          useCLI,
 		EnableAuthenticationUsingOIDC:              useOIDC,
 		EnableAuthenticationUsingGitHubOIDC:        useOIDC,
+	}, nil
+}
+
+// preConfigureCallback returns an error when cloud provider setup is misconfigured
+func preConfigureCallback(vars resource.PropertyMap, _ tfshim.ResourceConfig) error {
+	envName := tfbridge.ConfigStringValue(vars, "environment", []string{"ARM_ENVIRONMENT"})
+	if envName == "" {
+		envName = "public"
+	}
+
+	env, err := environments.FromName(envName)
+	if err != nil {
+		return fmt.Errorf("failed to read Azure environment \"%s\": %v", envName, err)
+	}
+
+	authConfig, err := getAuthConfig(vars, *env)
+	if err != nil {
+		return err
 	}
 
 	_, err = auth.NewAuthorizerFromCredentials(context.Background(), authConfig, env.MicrosoftGraph)

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -1,0 +1,208 @@
+// Copyright 2026, Pulumi Corporation.
+
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/environments"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func TestConfigBoolValue(t *testing.T) {
+	tests := []struct {
+		name         string
+		property     *bool
+		environment  string
+		defaultValue bool
+		want         bool
+	}{
+		{
+			name:         "uses default when unset",
+			defaultValue: true,
+			want:         true,
+		},
+		{
+			name:         "uses false environment value",
+			environment:  "false",
+			defaultValue: true,
+			want:         false,
+		},
+		{
+			name:         "uses values accepted by strconv ParseBool",
+			environment:  "1",
+			defaultValue: false,
+			want:         true,
+		},
+		{
+			name:         "explicit false overrides environment",
+			property:     boolPointer(false),
+			environment:  "true",
+			defaultValue: true,
+			want:         false,
+		},
+		{
+			name:         "explicit true overrides environment",
+			property:     boolPointer(true),
+			environment:  "false",
+			defaultValue: false,
+			want:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(armUseCLIEnv, tt.environment)
+			vars := resource.PropertyMap{}
+			if tt.property != nil {
+				vars[useCLIConfigKey] = resource.NewBoolProperty(*tt.property)
+			}
+
+			got, err := configBoolValue(vars, useCLIConfigKey, []string{armUseCLIEnv}, tt.defaultValue)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestConfigBoolValueRejectsInvalidEnvironmentValue(t *testing.T) {
+	t.Setenv(armUseCLIEnv, "not-a-boolean")
+
+	_, err := configBoolValue(resource.PropertyMap{}, useCLIConfigKey, []string{armUseCLIEnv}, true)
+	require.ErrorContains(t, err, "parsing ARM_USE_CLI as a boolean")
+}
+
+func TestGetAuthConfig(t *testing.T) {
+	t.Setenv(armUseCLIEnv, "true")
+	t.Setenv("ARM_OIDC_TOKEN", "")
+	t.Setenv("ARM_OIDC_TOKEN_FILE_PATH", "")
+
+	environment, err := environments.FromName("public")
+	require.NoError(t, err)
+	tokenPath := writeTokenFile(t, "file-token\n")
+
+	config, err := getAuthConfig(resource.PropertyMap{
+		useCLIConfigKey:            resource.NewBoolProperty(false),
+		"useOidc":                  resource.NewBoolProperty(true),
+		oidcTokenFilePathConfigKey: resource.NewStringProperty(tokenPath),
+	}, *environment)
+
+	require.NoError(t, err)
+	assert.False(t, config.EnableAuthenticatingUsingAzureCLI)
+	assert.True(t, config.EnableAuthenticationUsingOIDC)
+	assert.True(t, config.EnableAuthenticationUsingGitHubOIDC)
+	assert.Equal(t, "file-token", config.OIDCAssertionToken)
+}
+
+func TestGetAuthConfigDefaultsToAzureCLI(t *testing.T) {
+	t.Setenv(armUseCLIEnv, "")
+	t.Setenv("ARM_OIDC_TOKEN", "")
+	t.Setenv("ARM_OIDC_TOKEN_FILE_PATH", "")
+
+	environment, err := environments.FromName("public")
+	require.NoError(t, err)
+	config, err := getAuthConfig(resource.PropertyMap{}, *environment)
+
+	require.NoError(t, err)
+	assert.True(t, config.EnableAuthenticatingUsingAzureCLI)
+}
+
+func TestPreConfigureCallbackAcceptsOIDCTokenFileWithCLIDisabled(t *testing.T) {
+	t.Setenv("ARM_CLIENT_SECRET", "")
+	t.Setenv("ARM_CLIENT_CERTIFICATE_PATH", "")
+	t.Setenv("ARM_USE_MSI", "false")
+	t.Setenv("ARM_OIDC_TOKEN", "")
+	t.Setenv("ARM_OIDC_TOKEN_FILE_PATH", "")
+
+	tokenPath := writeTokenFile(t, "file-token\n")
+	err := preConfigureCallback(resource.PropertyMap{
+		clientIDConfigKey:          resource.NewStringProperty("00000000-0000-0000-0000-000000000001"),
+		"tenantId":                 resource.NewStringProperty("00000000-0000-0000-0000-000000000002"),
+		useCLIConfigKey:            resource.NewBoolProperty(false),
+		"useOidc":                  resource.NewBoolProperty(true),
+		oidcTokenFilePathConfigKey: resource.NewStringProperty(tokenPath),
+	}, nil)
+
+	require.NoError(t, err)
+}
+
+//nolint:goconst // repeated literals keep each token precedence case self-contained
+func TestGetOIDCToken(t *testing.T) {
+	t.Setenv("ARM_OIDC_TOKEN", "")
+	t.Setenv("ARM_OIDC_TOKEN_FILE_PATH", "")
+
+	t.Run("uses direct token", func(t *testing.T) {
+		token, err := getOIDCToken(resource.PropertyMap{
+			"oidcToken": resource.NewStringProperty("direct-token"),
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "direct-token", token)
+	})
+
+	t.Run("reads and trims file token", func(t *testing.T) {
+		path := writeTokenFile(t, "  file-token\n")
+		token, err := getOIDCToken(resource.PropertyMap{
+			"oidcTokenFilePath": resource.NewStringProperty(path),
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "file-token", token)
+	})
+
+	t.Run("accepts matching direct and file tokens", func(t *testing.T) {
+		path := writeTokenFile(t, "same-token\n")
+		token, err := getOIDCToken(resource.PropertyMap{
+			"oidcToken":         resource.NewStringProperty("same-token"),
+			"oidcTokenFilePath": resource.NewStringProperty(path),
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "same-token", token)
+	})
+
+	t.Run("rejects mismatched direct and file tokens", func(t *testing.T) {
+		path := writeTokenFile(t, "file-token")
+		_, err := getOIDCToken(resource.PropertyMap{
+			"oidcToken":         resource.NewStringProperty("direct-token"),
+			"oidcTokenFilePath": resource.NewStringProperty(path),
+		})
+
+		require.ErrorContains(t, err, "mismatch between supplied OIDC token")
+	})
+
+	t.Run("reports unreadable token file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing-token")
+		_, err := getOIDCToken(resource.PropertyMap{
+			"oidcTokenFilePath": resource.NewStringProperty(path),
+		})
+
+		require.ErrorContains(t, err, "reading OIDC token from file")
+	})
+
+	t.Run("uses environment token file", func(t *testing.T) {
+		path := writeTokenFile(t, "environment-token")
+		t.Setenv("ARM_OIDC_TOKEN_FILE_PATH", path)
+		token, err := getOIDCToken(resource.PropertyMap{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "environment-token", token)
+	})
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}
+
+func writeTokenFile(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "oidc-token")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}


### PR DESCRIPTION
## Summary

- honor `useCli` and `ARM_USE_CLI` in the Pulumi pre-configure authentication check while preserving the existing default of `true`
- load OIDC assertions from `oidcTokenFilePath` / `ARM_OIDC_TOKEN_FILE_PATH`, including upstream-compatible trimming and direct/file mismatch validation
- add focused unit coverage and a preview-only OIDC token-file integration test that disables alternate authentication paths

## Context

The Pulumi-specific pre-configure callback diverged from the upstream AzureAD provider by always enabling Azure CLI authentication and ignoring OIDC token files. Valid token-file configurations could therefore fail before upstream provider configuration ran.

The integration test stops after preview because the regression occurs while configuring the provider; no AzureAD resources need to be created or destroyed.

Fixes #2430.

## Testing

- `make lint`
- `make test_provider`
- `go test -run '^$' -tags=nodejs ./...` from `examples`
- `TestSimple_OIDC_TokenFile` passed locally using the `pulumi/providers/azure` ESC environment
- `make generate` (unrelated generated schema drift reverted)
