### PR TITLE
Fix UUID string error for ServicePrincipalID

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -4,6 +4,7 @@ go 1.26.4
 
 require (
 	github.com/hashicorp/go-azure-sdk/sdk v0.20260212.1143955
+	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-provider-azuread/shim v0.0.0
 	github.com/pulumi/providertest v0.7.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.137.0
@@ -119,7 +120,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.8.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
-	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/hashicorp/hc-install v0.9.3 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect

--- a/provider/provider_yaml_test.go
+++ b/provider/provider_yaml_test.go
@@ -7,18 +7,25 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 
 	_ "embed"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/providertest"
 	"github.com/pulumi/providertest/optproviderupgrade"
 	"github.com/pulumi/providertest/providers"
 	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/providertest/pulumitest/assertpreview"
+	"github.com/pulumi/providertest/pulumitest/optnewstack"
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"github.com/pulumi/pulumi-azuread/provider/v6/pkg/version"
@@ -33,6 +40,27 @@ func Test_ad_app_password(t *testing.T) {
 		filepath.Join("test-programs", "ad-app-password"),
 		"5.53.5",
 		optproviderupgrade.NewSourcePath(filepath.Join("test-programs", "ad-app-password", "v6")))
+}
+
+func TestServicePrincipalPasswordAcceptsBareUUIDFromV5State(t *testing.T) {
+	const program = "ad-sp-password"
+
+	rpFactory := providers.ResourceProviderFactory(providerServer)
+	pt := pulumitest.NewPulumiTest(t, filepath.Join("test-programs", program),
+		opttest.AttachProvider("azuread", rpFactory),
+		opttest.NewStackOptions(optnewstack.DisableAutoDestroy()))
+
+	raw, err := os.ReadFile(filepath.Join(providertest.GetUpgradeCacheDir(program, "5.53.5"), "stack.json"))
+	require.NoError(t, err)
+
+	var stack apitype.UntypedDeployment
+	require.NoError(t, json.Unmarshal(raw, &stack))
+	pt.ImportStack(t, stack)
+
+	previewResult := pt.Preview(t, optpreview.Diff())
+	assertpreview.HasNoReplacements(t, previewResult)
+	assertpreview.HasNoDeletes(t, previewResult)
+	require.NotContains(t, previewResult.StdErr, "error:")
 }
 
 func TestUpgradeCoverage(t *testing.T) {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
 	"github.com/hashicorp/go-azure-sdk/sdk/environments"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-provider-azuread/shim"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
@@ -220,7 +221,6 @@ func migrateApplicationState(_ context.Context, state resource.PropertyMap) (res
 // /servicePrincipals/{id} format change.
 func migrateServicePrincipalState(_ context.Context, state resource.PropertyMap) (resource.PropertyMap, error) {
 	backfillClientIDFromApplicationID(state)
-	prefixID(state, "/servicePrincipals/")
 	return state, nil
 }
 
@@ -236,6 +236,38 @@ func backfillClientIDFromApplicationID(state resource.PropertyMap) {
 		return
 	}
 	state[clientIDKey] = appID
+}
+
+func normalizeIDField(props resource.PropertyMap, field, prefix string) {
+	key := resource.PropertyKey(field)
+	v, ok := props[key]
+	if !ok || !v.IsString() {
+		return
+	}
+	s := v.StringValue()
+	if _, err := uuid.ParseUUID(s); err != nil {
+		return
+	}
+	props[key] = resource.NewStringProperty(prefix + s)
+}
+
+// v5 stored a ServicePrincipal's id as a bare UUID and only a refresh rewrites it, so
+// servicePrincipalId still arrives in that form after an upgrade and upstream rejects it.
+// Normalize the incoming value and the one already in state: the field is ForceNew, so
+// normalizing only one side would register as a change and force a replacement.
+func upgradeV5ServicePrincipalID(tok string) *tfbridge.ResourceInfo {
+	const field, prefix = "servicePrincipalId", "/servicePrincipals/"
+	return &tfbridge.ResourceInfo{
+		Tok: makeResource(mainMod, tok),
+		PreCheckCallback: func(_ context.Context, config, _ resource.PropertyMap) (resource.PropertyMap, error) {
+			normalizeIDField(config, field, prefix)
+			return config, nil
+		},
+		TransformFromState: func(_ context.Context, state resource.PropertyMap) (resource.PropertyMap, error) {
+			normalizeIDField(state, field, prefix)
+			return state, nil
+		},
+	}
 }
 
 func prefixID(state resource.PropertyMap, prefix string) {
@@ -311,7 +343,7 @@ func Provider() tfbridge.ProviderInfo {
 				Tok:                makeResource(mainMod, "ServicePrincipal"),
 				TransformFromState: migrateServicePrincipalState,
 			},
-			"azuread_service_principal_password": {Tok: makeResource(mainMod, "ServicePrincipalPassword")},
+			"azuread_service_principal_password": upgradeV5ServicePrincipalID("ServicePrincipalPassword"),
 			"azuread_service_principal_delegated_permission_grant": {
 				Tok: makeResource(mainMod, "ServicePrincipalDelegatedPermissionGrant"),
 			},

--- a/provider/state_migration_test.go
+++ b/provider/state_migration_test.go
@@ -140,28 +140,24 @@ func TestMigrateServicePrincipalState(t *testing.T) {
 		want resource.PropertyMap
 	}{
 		{
-			name: "v5 state is fully migrated",
+			name: "clientId is backfilled from applicationId",
 			in: resource.PropertyMap{
 				"applicationId": resource.NewStringProperty(guid),
-				"id":            resource.NewStringProperty(guid),
 			},
 			want: resource.PropertyMap{
 				"applicationId": resource.NewStringProperty(guid),
 				"clientId":      resource.NewStringProperty(guid),
-				"id":            resource.NewStringProperty("/servicePrincipals/" + guid),
 			},
 		},
 		{
-			name: "already-migrated state is unchanged",
+			name: "existing clientId is preserved",
 			in: resource.PropertyMap{
 				"applicationId": resource.NewStringProperty(guid),
-				"clientId":      resource.NewStringProperty(guid),
-				"id":            resource.NewStringProperty("/servicePrincipals/" + guid),
+				"clientId":      resource.NewStringProperty("custom"),
 			},
 			want: resource.PropertyMap{
 				"applicationId": resource.NewStringProperty(guid),
-				"clientId":      resource.NewStringProperty(guid),
-				"id":            resource.NewStringProperty("/servicePrincipals/" + guid),
+				"clientId":      resource.NewStringProperty("custom"),
 			},
 		},
 	}

--- a/provider/test-programs/ad-sp-password/Pulumi.yaml
+++ b/provider/test-programs/ad-sp-password/Pulumi.yaml
@@ -1,0 +1,12 @@
+name: ad-sp-password
+runtime: yaml
+description: Upgrading v5 ServicePrincipal state, whose id is a bare UUID
+resources:
+  example:
+    type: azuread:ServicePrincipal
+    properties:
+      clientId: 12697b3b-13f5-4ad4-bfb6-78e3cc5c6c49
+  password:
+    type: azuread:ServicePrincipalPassword
+    properties:
+      servicePrincipalId: ${example.id}

--- a/provider/testdata/recorded/TestProviderUpgrade/ad-sp-password/5.53.5/stack.json
+++ b/provider/testdata/recorded/TestProviderUpgrade/ad-sp-password/5.53.5/stack.json
@@ -1,0 +1,122 @@
+{
+  "version": 3,
+  "deployment": {
+    "manifest": {
+      "time": "2024-10-10T10:17:33.308559+01:00",
+      "magic": "3ee1df7d88e73eabd00b78d7e9adea0e78f7a7ee1e2702f04b35b87d31dbc1bb",
+      "version": "v3.135.1"
+    },
+    "secrets_providers": {
+      "type": "passphrase",
+      "state": {
+        "salt": "v1:Us8X3BsW8/w=:v1:n5GGST9lDiiM/Q6y:4n7LLG2geJENJK/VXoFOzIK1XkG78w=="
+      }
+    },
+    "resources": [
+      {
+        "urn": "urn:pulumi:test::ad-sp-password::pulumi:pulumi:Stack::ad-sp-password-test",
+        "custom": false,
+        "type": "pulumi:pulumi:Stack",
+        "created": "2024-10-10T09:17:22.41795Z",
+        "modified": "2024-10-10T09:17:22.41795Z"
+      },
+      {
+        "urn": "urn:pulumi:test::ad-sp-password::pulumi:providers:azuread::default",
+        "custom": true,
+        "id": "0114540b-c098-4ecb-8277-c223b402b317",
+        "type": "pulumi:providers:azuread",
+        "created": "2024-10-10T09:17:23.346837Z",
+        "modified": "2024-10-10T09:17:23.346837Z"
+      },
+      {
+        "urn": "urn:pulumi:test::ad-sp-password::azuread:index/servicePrincipal:ServicePrincipal::example",
+        "custom": true,
+        "id": "bbcb3cdf-4757-43be-a600-cb2bdad3455b",
+        "type": "azuread:index/servicePrincipal:ServicePrincipal",
+        "inputs": {
+          "__defaults": [
+            "accountEnabled",
+            "appRoleAssignmentRequired"
+          ],
+          "accountEnabled": true,
+          "appRoleAssignmentRequired": false,
+          "clientId": "12697b3b-13f5-4ad4-bfb6-78e3cc5c6c49"
+        },
+        "outputs": {
+          "__meta": "{\"e2bfb730-ecaa-11e6-8f88-34363bc7c4c0\": {\"create\": 600000000000, \"read\": 300000000000, \"update\": 600000000000, \"delete\": 300000000000}, \"schema_version\": \"0\"}",
+          "accountEnabled": true,
+          "alternativeNames": [],
+          "appRoleAssignmentRequired": false,
+          "appRoleIds": {},
+          "appRoles": [],
+          "applicationId": "12697b3b-13f5-4ad4-bfb6-78e3cc5c6c49",
+          "applicationTenantId": "3c7f2a1e-9d84-4b6f-8e21-5a0c7d93bf14",
+          "clientId": "12697b3b-13f5-4ad4-bfb6-78e3cc5c6c49",
+          "description": "",
+          "displayName": "example",
+          "featureTags": [],
+          "features": [],
+          "homepageUrl": "",
+          "id": "bbcb3cdf-4757-43be-a600-cb2bdad3455b",
+          "loginUrl": "",
+          "logoutUrl": "",
+          "notes": "",
+          "notificationEmailAddresses": [],
+          "oauth2PermissionScopeIds": {},
+          "oauth2PermissionScopes": [],
+          "objectId": "bbcb3cdf-4757-43be-a600-cb2bdad3455b",
+          "owners": [],
+          "preferredSingleSignOnMode": "",
+          "redirectUris": [],
+          "samlMetadataUrl": "",
+          "samlSingleSignOns": [],
+          "servicePrincipalNames": [
+            "12697b3b-13f5-4ad4-bfb6-78e3cc5c6c49"
+          ],
+          "signInAudience": "AzureADMyOrg",
+          "tags": [],
+          "type": "Application",
+          "useExisting": false
+        },
+        "parent": "urn:pulumi:test::ad-sp-password::pulumi:pulumi:Stack::ad-sp-password-test",
+        "provider": "urn:pulumi:test::ad-sp-password::pulumi:providers:azuread::default::0114540b-c098-4ecb-8277-c223b402b317",
+        "propertyDependencies": {
+          "clientId": []
+        },
+        "created": "2024-10-10T09:17:27.490323Z",
+        "modified": "2024-10-10T09:17:27.490323Z"
+      },
+      {
+        "urn": "urn:pulumi:test::ad-sp-password::azuread:index/servicePrincipalPassword:ServicePrincipalPassword::password",
+        "custom": true,
+        "id": "bbcb3cdf-4757-43be-a600-cb2bdad3455b/password/ef482963-8947-4bb9-883d-9742d685d378",
+        "type": "azuread:index/servicePrincipalPassword:ServicePrincipalPassword",
+        "inputs": {
+          "__defaults": [],
+          "servicePrincipalId": "bbcb3cdf-4757-43be-a600-cb2bdad3455b"
+        },
+        "outputs": {
+          "__meta": "{\"e2bfb730-ecaa-11e6-8f88-34363bc7c4c0\": {\"create\": 300000000000, \"read\": 300000000000, \"delete\": 300000000000}, \"schema_version\": \"1\"}",
+          "displayName": "example",
+          "endDate": "2026-10-10T09:17:33Z",
+          "id": "bbcb3cdf-4757-43be-a600-cb2bdad3455b/password/ef482963-8947-4bb9-883d-9742d685d378",
+          "keyId": "ef482963-8947-4bb9-883d-9742d685d378",
+          "servicePrincipalId": "bbcb3cdf-4757-43be-a600-cb2bdad3455b",
+          "startDate": "2024-10-10T09:17:33Z"
+        },
+        "parent": "urn:pulumi:test::ad-sp-password::pulumi:pulumi:Stack::ad-sp-password-test",
+        "dependencies": [
+          "urn:pulumi:test::ad-sp-password::azuread:index/servicePrincipal:ServicePrincipal::example"
+        ],
+        "provider": "urn:pulumi:test::ad-sp-password::pulumi:providers:azuread::default::0114540b-c098-4ecb-8277-c223b402b317",
+        "propertyDependencies": {
+          "servicePrincipalId": [
+            "urn:pulumi:test::ad-sp-password::azuread:index/servicePrincipal:ServicePrincipal::example"
+          ]
+        },
+        "created": "2024-10-10T09:17:33.304471Z",
+        "modified": "2024-10-10T09:17:33.304471Z"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Upstream rewrites the Service Principal UUID with a prefix during a major version upgrade. https://github.com/pulumi/pulumi-azuread/pull/2378 attempted to fix this via a state migration on Service Principal. But in doing so, we rewrote the prefix in the wrong place which then failed validation.
The real fix is to run a refresh operation upon upgrade, which will write the correct value to state.

To avoid users having to run a refresh, this PR removes the incorrect migration fix and additionally rewrites ServicePrincipalID input on ServicePrincipalPassword to the expected value on Check so the validation does not fail.

Alternatively, we could also only roll back the broken migration and instruct users to run a refresh on upgrade.

Fix for https://github.com/pulumi/pulumi-azuread/issues/2495.



